### PR TITLE
CUSTOM_MODELS - support wildcard and entire providerName

### DIFF
--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -52,11 +52,28 @@ export function collectModelTable(
         let count = 0;
         for (const fullName in modelTable) {
           const [modelName, providerName] = fullName.split("@");
+
+          let match = false;
           if (
             customModelName == modelName &&
             (customProviderName === undefined ||
               customProviderName === providerName)
-          ) {
+          ) match = true; //orginal full name match
+
+          if (!match && m.startsWith("-")) {
+            // if not match and it's '-'
+            if (nameConfig.startsWith("@")) {
+              if (nameConfig === "@" + providerName) match = true;
+            } else {
+              if (customModelName.includes("*")) {
+                const regexPattern = customModelName.replace(/\*/g, ".*");
+                const regex = new RegExp("^" + regexPattern + "$", "i");
+                if (regex.test(modelName)) match = true;
+              }
+            }
+          }
+
+          if (match) {
             count += 1;
             modelTable[fullName]["available"] = available;
             // swap name and displayName for bytedance
@@ -99,13 +116,16 @@ export function collectModelTableWithDefaultModel(
 ) {
   let modelTable = collectModelTable(models, customModels);
   if (defaultModel && defaultModel !== "") {
-    if (defaultModel.includes('@')) {
+    if (defaultModel.includes("@")) {
       if (defaultModel in modelTable) {
         modelTable[defaultModel].isDefault = true;
       }
     } else {
       for (const key of Object.keys(modelTable)) {
-        if (modelTable[key].available && key.split('@').shift() == defaultModel) {
+        if (
+          modelTable[key].available &&
+          key.split("@").shift() == defaultModel
+        ) {
           modelTable[key].isDefault = true;
           break;
         }


### PR DESCRIPTION
https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5050

for CUSTOM_MODELS
if start with "-", it supports -@providerName
and -modelname support wildcard (*), 
eg:
`CUSTOM_MODELS=-ernie-*,-doubao-*,-@azure`
