### PR TITLE
docs: Adding another one-click deploy option to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ One-Click to get a well-designed cross-platform ChatGPT web UI, with GPT3, GPT4 
 [MacOS-image]: https://img.shields.io/badge/-MacOS-black?logo=apple
 [Linux-image]: https://img.shields.io/badge/-Linux-333?logo=ubuntu
 
-[<img src="https://vercel.com/button" alt="Deploy on Zeabur" height="30">](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FChatGPTNextWeb%2FChatGPT-Next-Web&env=OPENAI_API_KEY&env=CODE&project-name=nextchat&repository-name=NextChat) [<img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" height="30">](https://zeabur.com/templates/ZBUEFA)  [<img src="https://gitpod.io/button/open-in-gitpod.svg" alt="Open in Gitpod" height="30">](https://gitpod.io/#https://github.com/Yidadaa/ChatGPT-Next-Web)
+[<img src="https://vercel.com/button" alt="Deploy on Zeabur" height="30">](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FChatGPTNextWeb%2FChatGPT-Next-Web&env=OPENAI_API_KEY&env=CODE&project-name=nextchat&repository-name=NextChat) [<img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" height="30">](https://zeabur.com/templates/ZBUEFA) [<img src="https://gitpod.io/button/open-in-gitpod.svg" alt="Open in Gitpod" height="30">](https://gitpod.io/#https://github.com/Yidadaa/ChatGPT-Next-Web) [<img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy to RepoCloud" height="30">](https://repocloud.io/details/?app_id=275)
 
 </div>
 


### PR DESCRIPTION
💻 变更类型 | Change Type
[x] docs <!-- 仅文档更新 | Documentation only changes -->

🔀 变更说明 | Description of Change
This Pull Request adds a new deployment option for the project. Specifically, it introduces a button that enables community access to deploy the template for self-hosting on RepoCloud with one click. This change enhances the accessibility and deployment options for users who wish to self-host the project.

The update includes:

1. Adding a new button image for RepoCloud deployment.
2. Integrating the RepoCloud deployment option alongside existing deployment methods (Vercel, Zeabur, and Gitpod).
3. Ensuring consistent styling with other deployment buttons for a cohesive look.

This addition provides users with more flexibility in choosing their preferred hosting platform and simplifies the process of deploying the project on RepoCloud.

📝 补充信息 | Additional Information
- The RepoCloud button uses the image URL: https://d16t0pc4846x52.cloudfront.net/deploylobe.svg
- The deployment link for RepoCloud is: https://repocloud.io/details/?app_id=275
- The button height has been set to 30 pixels to match existing buttons for visual consistency.
- This change only affects the README or documentation file where deployment options are listed.
- No code changes were required for this update.

This addition aligns with the project's goal of providing easy deployment options for users and expands the range of supported platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new deployment button for "Deploy to RepoCloud" in the README, expanding deployment options for users.
- **Documentation**
	- Updated README.md to include the new deployment option, ensuring a consistent design with existing buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->