### PR TITLE
Fix: Set consistent fill color for OpenAI/MoonShot/Grok SVG to prevent color inversion in dark mode

### DIFF
--- a/app/icons/llm-icons/grok.svg
+++ b/app/icons/llm-icons/grok.svg
@@ -1,4 +1,4 @@
-<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
+<svg fill="#333" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
      width="1em" xmlns="http://www.w3.org/2000/svg">
     <title>Grok</title>
     <rect width="30" height="30" fill="#E7F8FF" rx="6"/>

--- a/app/icons/llm-icons/moonshot.svg
+++ b/app/icons/llm-icons/moonshot.svg
@@ -1,4 +1,4 @@
-<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
+<svg fill="#333" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
      width="1em" xmlns="http://www.w3.org/2000/svg">
     <title>MoonshotAI</title>
     <rect width="30" height="30" fill="#E7F8FF" rx="6"/>

--- a/app/icons/llm-icons/openai.svg
+++ b/app/icons/llm-icons/openai.svg
@@ -1,4 +1,4 @@
-<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
+<svg fill="#333" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30"
      width="1em" xmlns="http://www.w3.org/2000/svg">
     <title>OpenAI</title>
     <rect width="30" height="30" fill="#E7F8FF" rx="6"/>


### PR DESCRIPTION
Fix: Set consistent fill color for OpenAI/MoonShot/Grok SVG to prevent color inversion in dark mode

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

The icons introduced in commit add9ca2 displayed incorrectly in dark mode. This update fixes the issue for the OpenAI, MoonShot, and Grok icons.
Commit add9ca2 引入的部分图标在暗黑模式下显示异常，本次更新修正了OpenAI/MoonShot/Grok等3个图标的该问题。
![屏幕截图 2025-02-07 110643](https://github.com/user-attachments/assets/1e10f441-2f5d-4945-81f3-e61d5485e200)


#### 📝 补充信息 | Additional Information

The fill color has been specified to prevent changes with the parent element's color in dark mode. No other changes are involved.
指定了填充颜色，以避免暗黑模式下随父元素颜色变化，不涉及其他更改。
