### PR TITLE
Larger timeout for SiliconFlow

### DIFF
--- a/app/client/platforms/siliconflow.ts
+++ b/app/client/platforms/siliconflow.ts
@@ -121,10 +121,10 @@ export class SiliconflowApi implements LLMApi {
       // console.log(chatPayload);
 
       // make a fetch request
-      const requestTimeoutId = setTimeout(
-        () => controller.abort(),
-        REQUEST_TIMEOUT_MS,
-      );
+      const requestTimeoutId = setTimeout(() => {
+        console.error("[Request] SiliconFlow API timeout");
+        controller.abort();
+      }, 10 * REQUEST_TIMEOUT_MS);
 
       if (shouldStream) {
         const [tools, funcs] = usePluginStore


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] fix   10x the timeout for SiliconFlow for the reasoning model

#### 🔀 变更说明 | Description of Change

因为带 reasoning 的模型（如 DeepSeek-R1 ）推理可能要超过1分钟才会完整返回内容，将 SiliconFlow 平台的 timeout 改为10分钟



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes  
 - Improved chat request handling by extending the timeout period and providing clearer error notifications during delays. These changes help optimize system responses under network strain, contributing to a more robust and reliable communication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->