### PR TITLE
集成 AWS Bedrock 作为新的 LLM 服务提供商

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -57,7 +57,7 @@ DISABLE_FAST_LINK=
 # (optional)
 # Default: Empty
 # To control custom models, use + to add a custom model, use - to hide a model, use name=displayName to customize model name, separated by comma.
-CUSTOM_MODELS=
+CUSTOM_MODELS=-all,+gpt-4o-2024-11-20@openai=gpt-4o,+gpt-4o-mini@openai,+us.anthropic.claude-3-5-sonnet-20241022-v2:0@bedrock=sonnet
 
 # (optional)
 # Default: Empty
@@ -81,3 +81,22 @@ SILICONFLOW_API_KEY=
 
 ### siliconflow Api url (optional)
 SILICONFLOW_URL=
+
+# --- AWS Bedrock Section --- 
+# Ensure these lines for keys either have placeholder values like below,
+# are commented out entirely, or removed if they shouldn't be in the template.
+
+# AWS Access Key for Bedrock API (Example: Use placeholder or comment out)
+# AWS_ACCESS_KEY_ID=
+
+# AWS Secret Access Key for Bedrock API (Example: Use placeholder or comment out)
+# AWS_SECRET_ACCESS_KEY=
+
+# AWS Region for Bedrock API (e.g. us-east-1, us-west-2)
+AWS_REGION=
+
+# Enable AWS Bedrock models (set to "true" to enable)
+ENABLE_AWS_BEDROCK=
+
+# Custom endpoint URL for AWS Bedrock (optional)
+AWS_BEDROCK_ENDPOINT=

--- a/app/api/[provider]/[...path]/route.ts
+++ b/app/api/[provider]/[...path]/route.ts
@@ -14,6 +14,7 @@ import { handle as deepseekHandler } from "../../deepseek";
 import { handle as siliconflowHandler } from "../../siliconflow";
 import { handle as xaiHandler } from "../../xai";
 import { handle as chatglmHandler } from "../../glm";
+import { handle as bedrockHandler } from "../../bedrock";
 import { handle as proxyHandler } from "../../proxy";
 
 async function handle(
@@ -50,6 +51,8 @@ async function handle(
       return chatglmHandler(req, { params });
     case ApiPath.SiliconFlow:
       return siliconflowHandler(req, { params });
+    case ApiPath.Bedrock:
+      return bedrockHandler(req, { params });
     case ApiPath.OpenAI:
       return openaiHandler(req, { params });
     default:

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -56,14 +56,6 @@ export function auth(req: NextRequest, modelProvider: ModelProvider) {
   // if user does not provide an api key, inject system api key
   if (!apiKey) {
     const serverConfig = getServerSideConfig();
-
-    // const systemApiKey =
-    //   modelProvider === ModelProvider.GeminiPro
-    //     ? serverConfig.googleApiKey
-    //     : serverConfig.isAzure
-    //     ? serverConfig.azureApiKey
-    //     : serverConfig.apiKey;
-
     let systemApiKey: string | undefined;
 
     switch (modelProvider) {
@@ -104,6 +96,11 @@ export function auth(req: NextRequest, modelProvider: ModelProvider) {
       case ModelProvider.SiliconFlow:
         systemApiKey = serverConfig.siliconFlowApiKey;
         break;
+      case ModelProvider.Bedrock:
+        console.log(
+          "[Auth] Using AWS credentials for Bedrock, no API key override.",
+        );
+        return { error: false };
       case ModelProvider.GPT:
       default:
         if (req.nextUrl.pathname.includes("azure/deployments")) {
@@ -117,7 +114,10 @@ export function auth(req: NextRequest, modelProvider: ModelProvider) {
       console.log("[Auth] use system api key");
       req.headers.set("Authorization", `Bearer ${systemApiKey}`);
     } else {
-      console.log("[Auth] admin did not provide an api key");
+      console.log(
+        "[Auth] admin did not provide an api key for provider:",
+        modelProvider,
+      );
     }
   } else {
     console.log("[Auth] use user api key");

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -1,0 +1,241 @@
+import { ModelProvider, Bedrock as BedrockConfig } from "@/app/constant";
+import { getServerSideConfig } from "@/app/config/server";
+import { prettyObject } from "@/app/utils/format";
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "../auth";
+import {
+  BedrockRuntimeClient,
+  InvokeModelWithResponseStreamCommand,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const ALLOWED_PATH = new Set([BedrockConfig.ChatPath]);
+
+// Helper to get AWS Credentials
+function getAwsCredentials() {
+  const config = getServerSideConfig();
+  if (!config.isBedrock) {
+    throw new Error("AWS Bedrock is not configured properly");
+  }
+  return {
+    accessKeyId: config.bedrockAccessKeyId as string,
+    secretAccessKey: config.bedrockSecretAccessKey as string,
+  };
+}
+
+export async function handle(
+  req: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  console.log("[Bedrock Route] params ", params);
+
+  if (req.method === "OPTIONS") {
+    return NextResponse.json({ body: "OK" }, { status: 200 });
+  }
+
+  const subpath = params.path.join("/");
+
+  if (!ALLOWED_PATH.has(subpath)) {
+    console.log("[Bedrock Route] forbidden path ", subpath);
+    return NextResponse.json(
+      { error: true, msg: "you are not allowed to request " + subpath },
+      { status: 403 },
+    );
+  }
+
+  // Auth check specifically for Bedrock (might not need header API key)
+  const authResult = auth(req, ModelProvider.Bedrock);
+  if (authResult.error) {
+    return NextResponse.json(authResult, { status: 401 });
+  }
+
+  try {
+    const config = getServerSideConfig();
+    if (!config.isBedrock) {
+      // This check might be redundant due to getAwsCredentials, but good practice
+      return NextResponse.json(
+        { error: true, msg: "AWS Bedrock is not configured properly" },
+        { status: 500 },
+      );
+    }
+
+    const bedrockRegion = config.bedrockRegion as string;
+    const bedrockEndpoint = config.bedrockEndpoint;
+
+    const client = new BedrockRuntimeClient({
+      region: bedrockRegion,
+      credentials: getAwsCredentials(),
+      endpoint: bedrockEndpoint || undefined,
+    });
+
+    const body = await req.json();
+    console.log("[Bedrock] request body: ", body);
+
+    const {
+      messages,
+      model,
+      stream = false,
+      temperature = 0.7,
+      max_tokens,
+    } = body;
+
+    // --- Payload formatting for Claude on Bedrock ---
+    const isClaudeModel = model.includes("anthropic.claude");
+    if (!isClaudeModel) {
+      return NextResponse.json(
+        { error: true, msg: "Unsupported Bedrock model: " + model },
+        { status: 400 },
+      );
+    }
+
+    const systemPrompts = messages.filter((msg: any) => msg.role === "system");
+    const userAssistantMessages = messages.filter(
+      (msg: any) => msg.role !== "system",
+    );
+
+    const payload = {
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: max_tokens || 4096,
+      temperature: temperature,
+      messages: userAssistantMessages.map((msg: any) => ({
+        role: msg.role, // 'user' or 'assistant'
+        content:
+          typeof msg.content === "string"
+            ? [{ type: "text", text: msg.content }]
+            : msg.content, // Assuming MultimodalContent format is compatible
+      })),
+      ...(systemPrompts.length > 0 && {
+        system: systemPrompts.map((msg: any) => msg.content).join("\n"),
+      }),
+    };
+    // --- End Payload Formatting ---
+
+    if (stream) {
+      const command = new InvokeModelWithResponseStreamCommand({
+        modelId: model,
+        contentType: "application/json",
+        accept: "application/json",
+        body: JSON.stringify(payload),
+      });
+      const response = await client.send(command);
+
+      if (!response.body) {
+        throw new Error("Empty response stream from Bedrock");
+      }
+      const responseBody = response.body;
+
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      const readableStream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const event of responseBody) {
+              if (event.chunk?.bytes) {
+                const chunkData = JSON.parse(decoder.decode(event.chunk.bytes));
+                let responseText = "";
+                let finishReason: string | null = null;
+
+                if (
+                  chunkData.type === "content_block_delta" &&
+                  chunkData.delta.type === "text_delta"
+                ) {
+                  responseText = chunkData.delta.text || "";
+                } else if (chunkData.type === "message_stop") {
+                  finishReason =
+                    chunkData["amazon-bedrock-invocationMetrics"]
+                      ?.outputTokenCount > 0
+                      ? "stop"
+                      : "length"; // Example logic
+                }
+
+                // Format as OpenAI SSE chunk
+                const sseData = {
+                  id: `chatcmpl-${nanoid()}`,
+                  object: "chat.completion.chunk",
+                  created: Math.floor(Date.now() / 1000),
+                  model: model,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { content: responseText },
+                      finish_reason: finishReason,
+                    },
+                  ],
+                };
+                controller.enqueue(
+                  encoder.encode(`data: ${JSON.stringify(sseData)}\n\n`),
+                );
+
+                if (finishReason) {
+                  controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                  break; // Exit loop after stop message
+                }
+              }
+            }
+          } catch (error) {
+            console.error("[Bedrock] Streaming error:", error);
+            controller.error(error);
+          } finally {
+            controller.close();
+          }
+        },
+      });
+
+      return new NextResponse(readableStream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    } else {
+      // Non-streaming response
+      const command = new InvokeModelCommand({
+        modelId: model,
+        contentType: "application/json",
+        accept: "application/json",
+        body: JSON.stringify(payload),
+      });
+      const response = await client.send(command);
+      const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+
+      // Format response to match OpenAI
+      const formattedResponse = {
+        id: `chatcmpl-${nanoid()}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: responseBody.content?.[0]?.text ?? "",
+            },
+            finish_reason: "stop", // Assuming stop for non-streamed
+          },
+        ],
+        usage: {
+          prompt_tokens:
+            responseBody["amazon-bedrock-invocationMetrics"]?.inputTokenCount ??
+            -1,
+          completion_tokens:
+            responseBody["amazon-bedrock-invocationMetrics"]
+              ?.outputTokenCount ?? -1,
+          total_tokens:
+            (responseBody["amazon-bedrock-invocationMetrics"]
+              ?.inputTokenCount ?? 0) +
+              (responseBody["amazon-bedrock-invocationMetrics"]
+                ?.outputTokenCount ?? 0) || -1,
+        },
+      };
+      return NextResponse.json(formattedResponse);
+    }
+  } catch (e) {
+    console.error("[Bedrock] API Handler Error:", e);
+    return NextResponse.json(prettyObject(e), { status: 500 });
+  }
+}
+
+// Need nanoid for unique IDs
+import { nanoid } from "nanoid";

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -76,8 +76,36 @@ export async function handle(
       "Stream:",
       body.stream,
       "Messages count:",
-      body.messages.length,
+      body.messages?.length || 0,
     );
+
+    // Add detailed logging for debugging
+    if (body.messages && body.messages.length > 0) {
+      body.messages.forEach((msg: any, index: number) => {
+        console.log(`[Bedrock] Message ${index}:`, {
+          role: msg.role,
+          contentType: typeof msg.content,
+          isArray: Array.isArray(msg.content),
+          contentLength: Array.isArray(msg.content)
+            ? msg.content.length
+            : typeof msg.content === "string"
+            ? msg.content.length
+            : "unknown",
+        });
+
+        if (Array.isArray(msg.content)) {
+          msg.content.forEach((item: any, itemIndex: number) => {
+            console.log(`[Bedrock] Message ${index}, Item ${itemIndex}:`, {
+              type: item.type,
+              hasImageUrl: !!item.image_url?.url,
+              urlPreview: item.image_url?.url
+                ? item.image_url.url.substring(0, 50) + "..."
+                : null,
+            });
+          });
+        }
+      });
+    }
 
     const {
       messages,
@@ -86,6 +114,27 @@ export async function handle(
       temperature = 0.7,
       max_tokens,
     } = body;
+
+    // --- Input Validation ---
+    if (!model || typeof model !== "string") {
+      return NextResponse.json(
+        {
+          error: true,
+          msg: "Model parameter is required and must be a string",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json(
+        {
+          error: true,
+          msg: "Messages parameter is required and must be a non-empty array",
+        },
+        { status: 400 },
+      );
+    }
 
     // --- Payload formatting for Claude on Bedrock ---
     const isClaudeModel = model.includes("anthropic.claude");
@@ -101,22 +150,297 @@ export async function handle(
       (msg: any) => msg.role !== "system",
     );
 
+    // Validate we have non-system messages
+    if (userAssistantMessages.length === 0) {
+      return NextResponse.json(
+        {
+          error: true,
+          msg: "At least one user or assistant message is required",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Process messages and handle image fetching
+    const processedMessages = await Promise.all(
+      userAssistantMessages.map(async (msg: any) => {
+        let content;
+
+        if (Array.isArray(msg.content)) {
+          const processedContent = await Promise.all(
+            msg.content.map(async (item: any) => {
+              if (item.type === "image_url") {
+                console.log("[Bedrock] Processing image_url item:", item);
+                // Adapt from OpenAI format to Bedrock's format
+                const url = item.image_url?.url;
+                if (!url) {
+                  console.warn(
+                    "[Bedrock] Image URL is missing in content item",
+                  );
+                  return null;
+                }
+
+                // Check if it's a data URL or regular URL
+                const dataUrlMatch = url.match(
+                  /^data:(image\/[^;]+);base64,(.+)$/,
+                );
+                if (dataUrlMatch) {
+                  // Handle data URL (base64)
+                  const mediaType = dataUrlMatch[1];
+                  const base64Data = dataUrlMatch[2];
+
+                  if (!base64Data) {
+                    console.warn("[Bedrock] Empty base64 data in image URL");
+                    return null;
+                  }
+
+                  const bedrockImageItem = {
+                    type: "image",
+                    source: {
+                      type: "base64",
+                      media_type: mediaType,
+                      data: base64Data,
+                    },
+                  };
+
+                  console.log(
+                    "[Bedrock] Successfully converted data URL to Bedrock format:",
+                    {
+                      mediaType,
+                      dataLength: base64Data.length,
+                    },
+                  );
+
+                  return bedrockImageItem;
+                } else if (
+                  url.startsWith("http://") ||
+                  url.startsWith("https://")
+                ) {
+                  // Handle HTTP URL - fetch directly and convert to base64
+                  console.log(
+                    "[Bedrock] HTTP URL detected, fetching directly:",
+                    url.substring(0, 50) + "...",
+                  );
+
+                  try {
+                    const response = await fetch(url);
+                    console.log(
+                      "[Bedrock] Fetch response status:",
+                      response.status,
+                      response.statusText,
+                    );
+
+                    if (!response.ok) {
+                      console.error(
+                        "[Bedrock] Failed to fetch image:",
+                        response.status,
+                        response.statusText,
+                      );
+                      return null;
+                    }
+
+                    const blob = await response.blob();
+                    console.log("[Bedrock] Blob info:", {
+                      size: blob.size,
+                      type: blob.type,
+                    });
+
+                    if (blob.size === 0) {
+                      console.error(
+                        "[Bedrock] Fetched blob is empty - cache endpoint may not be working",
+                      );
+                      console.log(
+                        "[Bedrock] This might be a service worker cache issue - image was uploaded but cache retrieval failed",
+                      );
+                      return null;
+                    }
+
+                    const arrayBuffer = await blob.arrayBuffer();
+                    console.log(
+                      "[Bedrock] ArrayBuffer size:",
+                      arrayBuffer.byteLength,
+                    );
+
+                    if (arrayBuffer.byteLength === 0) {
+                      console.error("[Bedrock] ArrayBuffer is empty");
+                      return null;
+                    }
+
+                    const base64Data =
+                      Buffer.from(arrayBuffer).toString("base64");
+                    console.log("[Bedrock] Base64 conversion:", {
+                      originalSize: arrayBuffer.byteLength,
+                      base64Length: base64Data.length,
+                      isEmpty: !base64Data || base64Data.length === 0,
+                      firstChars: base64Data.substring(0, 20),
+                    });
+
+                    if (!base64Data || base64Data.length === 0) {
+                      console.error(
+                        "[Bedrock] Base64 data is empty after conversion",
+                      );
+                      return null;
+                    }
+
+                    const mediaType = blob.type || "image/jpeg";
+
+                    const bedrockImageItem = {
+                      type: "image",
+                      source: {
+                        type: "base64",
+                        media_type: mediaType,
+                        data: base64Data,
+                      },
+                    };
+
+                    console.log(
+                      "[Bedrock] Successfully converted HTTP URL to Bedrock format:",
+                      {
+                        url: url.substring(0, 50) + "...",
+                        mediaType,
+                        dataLength: base64Data.length,
+                        hasValidData: !!base64Data && base64Data.length > 0,
+                      },
+                    );
+
+                    return bedrockImageItem;
+                  } catch (error) {
+                    console.error("[Bedrock] Error fetching image:", error);
+                    return null;
+                  }
+                } else {
+                  console.warn(
+                    "[Bedrock] Invalid URL format:",
+                    url.substring(0, 50) + "...",
+                  );
+                  return null;
+                }
+              } else {
+                // Handle text content
+                return item;
+              }
+            }),
+          );
+
+          // Filter out nulls and ensure we have content
+          content = processedContent.filter(Boolean);
+
+          // Additional validation: ensure no image objects have empty data
+          content = content.filter((item: any) => {
+            if (item.type === "image") {
+              const hasValidData =
+                item.source?.data && item.source.data.length > 0;
+              if (!hasValidData) {
+                console.error(
+                  "[Bedrock] Filtering out image with empty data:",
+                  {
+                    hasSource: !!item.source,
+                    hasData: !!item.source?.data,
+                    dataLength: item.source?.data?.length || 0,
+                  },
+                );
+                return false;
+              }
+            }
+            return true;
+          });
+
+          if (content.length === 0) {
+            console.warn(
+              "[Bedrock] All content items were filtered out, adding empty text",
+            );
+            content = [{ type: "text", text: "" }];
+          }
+
+          console.log(
+            "[Bedrock] Processed content for message:",
+            content.length,
+            "items",
+          );
+        } else if (typeof msg.content === "string") {
+          content = [{ type: "text", text: msg.content }];
+        } else {
+          console.warn("[Bedrock] Unknown content type:", typeof msg.content);
+          content = [{ type: "text", text: "" }];
+        }
+
+        return {
+          role: msg.role,
+          content: content,
+        };
+      }),
+    );
+
     const payload = {
       anthropic_version: "bedrock-2023-05-31",
-      max_tokens: max_tokens || 4096,
-      temperature: temperature,
-      messages: userAssistantMessages.map((msg: any) => ({
-        role: msg.role, // 'user' or 'assistant'
-        content:
-          typeof msg.content === "string"
-            ? [{ type: "text", text: msg.content }]
-            : msg.content, // Assuming MultimodalContent format is compatible
-      })),
+      max_tokens:
+        typeof max_tokens === "number" && max_tokens > 0 ? max_tokens : 4096,
+      temperature:
+        typeof temperature === "number" && temperature >= 0 && temperature <= 1
+          ? temperature
+          : 0.7, // Bedrock Claude accepts 0-1 range
+      messages: processedMessages,
       ...(systemPrompts.length > 0 && {
-        system: systemPrompts.map((msg: any) => msg.content).join("\n"),
+        system: systemPrompts
+          .map((msg: any) => {
+            if (typeof msg.content === "string") {
+              return msg.content;
+            } else if (Array.isArray(msg.content)) {
+              // Handle multimodal system prompts by extracting text
+              return msg.content
+                .filter((item: any) => item.type === "text")
+                .map((item: any) => item.text)
+                .join(" ");
+            }
+            return String(msg.content); // Fallback conversion
+          })
+          .filter(Boolean)
+          .join("\n"),
       }),
     };
     // --- End Payload Formatting ---
+
+    // Log the final payload structure (without base64 data to avoid huge logs)
+    console.log("[Bedrock] Final payload structure:", {
+      anthropic_version: payload.anthropic_version,
+      max_tokens: payload.max_tokens,
+      temperature: payload.temperature,
+      messageCount: payload.messages.length,
+      messages: payload.messages.map((msg: any, index: number) => ({
+        index,
+        role: msg.role,
+        contentItems: msg.content.map((item: any) => ({
+          type: item.type,
+          hasData: item.type === "image" ? !!item.source?.data : !!item.text,
+          mediaType: item.source?.media_type || null,
+          textLength: item.text?.length || null,
+          dataLength: item.source?.data?.length || null,
+        })),
+      })),
+      hasSystem: !!(payload as any).system,
+    });
+
+    // Final validation: check for any empty images
+    const hasEmptyImages = payload.messages.some((msg: any) =>
+      msg.content.some(
+        (item: any) =>
+          item.type === "image" &&
+          (!item.source?.data || item.source.data.length === 0),
+      ),
+    );
+
+    if (hasEmptyImages) {
+      console.error(
+        "[Bedrock] Payload contains empty images, this will cause Bedrock to fail",
+      );
+      return NextResponse.json(
+        {
+          error: true,
+          msg: "Image processing failed: empty image data detected",
+        },
+        { status: 400 },
+      );
+    }
 
     if (stream) {
       const command = new InvokeModelWithResponseStreamCommand({
@@ -139,13 +463,23 @@ export async function handle(
           try {
             for await (const event of responseBody) {
               if (event.chunk?.bytes) {
-                const chunkData = JSON.parse(decoder.decode(event.chunk.bytes));
+                let chunkData;
+                try {
+                  chunkData = JSON.parse(decoder.decode(event.chunk.bytes));
+                } catch (parseError) {
+                  console.error(
+                    "[Bedrock] Failed to parse chunk JSON:",
+                    parseError,
+                  );
+                  continue; // Skip malformed chunks
+                }
+
                 let responseText = "";
                 let finishReason: string | null = null;
 
                 if (
                   chunkData.type === "content_block_delta" &&
-                  chunkData.delta.type === "text_delta"
+                  chunkData.delta?.type === "text_delta"
                 ) {
                   responseText = chunkData.delta.text || "";
                 } else if (chunkData.type === "message_stop") {
@@ -156,35 +490,68 @@ export async function handle(
                       : "length"; // Example logic
                 }
 
-                // Format as OpenAI SSE chunk
-                const sseData = {
-                  id: `chatcmpl-${nanoid()}`,
-                  object: "chat.completion.chunk",
-                  created: Math.floor(Date.now() / 1000),
-                  model: model,
-                  choices: [
-                    {
-                      index: 0,
-                      delta: { content: responseText },
-                      finish_reason: finishReason,
-                    },
-                  ],
-                };
-                controller.enqueue(
-                  encoder.encode(`data: ${JSON.stringify(sseData)}\n\n`),
-                );
+                // Only send non-empty responses or finish signals
+                if (responseText || finishReason) {
+                  // Format as OpenAI SSE chunk
+                  const sseData = {
+                    id: `chatcmpl-${nanoid()}`,
+                    object: "chat.completion.chunk",
+                    created: Math.floor(Date.now() / 1000),
+                    model: model,
+                    choices: [
+                      {
+                        index: 0,
+                        delta: { content: responseText },
+                        finish_reason: finishReason,
+                      },
+                    ],
+                  };
+
+                  try {
+                    controller.enqueue(
+                      encoder.encode(`data: ${JSON.stringify(sseData)}\n\n`),
+                    );
+                  } catch (enqueueError) {
+                    console.error(
+                      "[Bedrock] Failed to enqueue data:",
+                      enqueueError,
+                    );
+                    break; // Stop processing if client disconnected
+                  }
+                }
 
                 if (finishReason) {
-                  controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                  try {
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                  } catch (enqueueError) {
+                    console.error(
+                      "[Bedrock] Failed to enqueue [DONE]:",
+                      enqueueError,
+                    );
+                  }
                   break; // Exit loop after stop message
                 }
               }
             }
           } catch (error) {
             console.error("[Bedrock] Streaming error:", error);
-            controller.error(error);
+            try {
+              controller.error(error);
+            } catch (controllerError) {
+              console.error(
+                "[Bedrock] Failed to signal controller error:",
+                controllerError,
+              );
+            }
           } finally {
-            controller.close();
+            try {
+              controller.close();
+            } catch (closeError) {
+              console.error(
+                "[Bedrock] Failed to close controller:",
+                closeError,
+              );
+            }
           }
         },
       });
@@ -205,7 +572,28 @@ export async function handle(
         body: JSON.stringify(payload),
       });
       const response = await client.send(command);
-      const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+
+      if (!response.body) {
+        throw new Error("Empty response body from Bedrock");
+      }
+
+      let responseBody;
+      try {
+        responseBody = JSON.parse(new TextDecoder().decode(response.body));
+      } catch (parseError) {
+        console.error("[Bedrock] Failed to parse response JSON:", parseError);
+        throw new Error("Invalid JSON response from Bedrock");
+      }
+
+      // Validate response structure
+      if (
+        !responseBody.content ||
+        !Array.isArray(responseBody.content) ||
+        responseBody.content.length === 0
+      ) {
+        console.error("[Bedrock] Invalid response structure:", responseBody);
+        throw new Error("Invalid response structure from Bedrock");
+      }
 
       // Format response to match OpenAI
       const formattedResponse = {

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -59,13 +59,6 @@ export async function handle(
 
   try {
     const config = getServerSideConfig();
-    if (!config.isBedrock) {
-      // This check might be redundant due to getAwsCredentials, but good practice
-      return NextResponse.json(
-        { error: true, msg: "AWS Bedrock is not configured properly" },
-        { status: 500 },
-      );
-    }
 
     const bedrockRegion = config.bedrockRegion as string;
     const bedrockEndpoint = config.bedrockEndpoint;

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -77,7 +77,14 @@ export async function handle(
     });
 
     const body = await req.json();
-    console.log("[Bedrock] request body: ", body);
+    console.log(
+      "[Bedrock] Request - Model:",
+      body.model,
+      "Stream:",
+      body.stream,
+      "Messages count:",
+      body.messages.length,
+    );
 
     const {
       messages,

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -374,7 +374,7 @@ export async function handle(
     const payload = {
       anthropic_version: "bedrock-2023-05-31",
       max_tokens:
-        typeof max_tokens === "number" && max_tokens > 0 ? max_tokens : 4096,
+        typeof max_tokens === "number" && max_tokens > 0 ? max_tokens : 8000,
       temperature:
         typeof temperature === "number" && temperature >= 0 && temperature <= 1
           ? temperature

--- a/app/api/bedrock/index.ts
+++ b/app/api/bedrock/index.ts
@@ -15,7 +15,15 @@ const ALLOWED_PATH = new Set([BedrockConfig.ChatPath]);
 function getAwsCredentials() {
   const config = getServerSideConfig();
   if (!config.isBedrock) {
-    throw new Error("AWS Bedrock is not configured properly");
+    throw new Error(
+      "AWS Bedrock is not configured properly (ENABLE_AWS_BEDROCK is not true)",
+    );
+  }
+  if (!config.bedrockAccessKeyId) {
+    throw new Error("AWS Bedrock Access Key ID is missing or empty.");
+  }
+  if (!config.bedrockSecretAccessKey) {
+    throw new Error("AWS Bedrock Secret Access Key is missing or empty.");
   }
   return {
     accessKeyId: config.bedrockAccessKeyId as string,

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -361,10 +361,45 @@ export function getHeaders(ignoreHeaders: boolean = false) {
 }
 
 export function getClientApi(provider: ServiceProvider | string): ClientApi {
-  switch (provider) {
+  console.log(
+    "[getClientApi] Received Provider (raw):",
+    provider,
+    "| Type:",
+    typeof provider,
+  );
+
+  // Standardize the provider name to match Enum case (TitleCase)
+  let standardizedProvider: ServiceProvider | string;
+  if (typeof provider === "string") {
+    // Convert known lowercase versions to their Enum equivalent
+    switch (provider.toLowerCase()) {
+      case "bedrock":
+        standardizedProvider = ServiceProvider.Bedrock;
+        break;
+      case "openai":
+        standardizedProvider = ServiceProvider.OpenAI;
+        break;
+      case "google":
+        standardizedProvider = ServiceProvider.Google;
+        break;
+      // Add other potential lowercase strings if needed
+      default:
+        standardizedProvider = provider; // Keep unknown strings as is
+    }
+  } else {
+    standardizedProvider = provider; // Already an Enum value
+  }
+
+  console.log("[getClientApi] Standardized Provider:", standardizedProvider);
+
+  switch (standardizedProvider) {
     case ServiceProvider.Google:
+      console.log(
+        "[getClientApi] Returning ClientApi(ModelProvider.GeminiPro)",
+      );
       return new ClientApi(ModelProvider.GeminiPro);
     case ServiceProvider.Anthropic:
+      console.log("[getClientApi] Returning ClientApi(ModelProvider.Claude)");
       return new ClientApi(ModelProvider.Claude);
     case ServiceProvider.Baidu:
       return new ClientApi(ModelProvider.Ernie);
@@ -387,9 +422,15 @@ export function getClientApi(provider: ServiceProvider | string): ClientApi {
     case ServiceProvider.SiliconFlow:
       return new ClientApi(ModelProvider.SiliconFlow);
     case ServiceProvider.Bedrock:
-    case "AWS Bedrock":
+      console.log(
+        "[getClientApi] Returning ClientApi(ModelProvider.Bedrock) for",
+        standardizedProvider,
+      );
       return new ClientApi(ModelProvider.Bedrock);
     default:
+      console.log(
+        `[getClientApi] Provider '${provider}' (Standardized: '${standardizedProvider}') not matched, returning default GPT.`,
+      );
       return new ClientApi(ModelProvider.GPT);
   }
 }

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -366,31 +366,57 @@ export function getClientApi(provider: ServiceProvider | string): ClientApi {
     provider,
     "| Type:",
     typeof provider,
+    "| Browser:",
+    navigator.userAgent.includes("Edge")
+      ? "Edge"
+      : navigator.userAgent.includes("Safari")
+      ? "Safari"
+      : "Other",
   );
 
   // Standardize the provider name to match Enum case (TitleCase)
   let standardizedProvider: ServiceProvider | string;
   if (typeof provider === "string") {
+    console.log(
+      "[getClientApi] Provider is string, attempting to standardize:",
+      provider,
+    );
     // Convert known lowercase versions to their Enum equivalent
     switch (provider.toLowerCase()) {
       case "bedrock":
         standardizedProvider = ServiceProvider.Bedrock;
+        console.log(
+          "[getClientApi] Converted 'bedrock' string to ServiceProvider.Bedrock",
+        );
         break;
       case "openai":
         standardizedProvider = ServiceProvider.OpenAI;
+        console.log(
+          "[getClientApi] Converted 'openai' string to ServiceProvider.OpenAI",
+        );
         break;
       case "google":
         standardizedProvider = ServiceProvider.Google;
         break;
       // Add other potential lowercase strings if needed
       default:
+        console.log(
+          "[getClientApi] Unknown string provider, keeping as-is:",
+          provider,
+        );
         standardizedProvider = provider; // Keep unknown strings as is
     }
   } else {
+    console.log("[getClientApi] Provider is already enum value:", provider);
     standardizedProvider = provider; // Already an Enum value
   }
 
-  console.log("[getClientApi] Standardized Provider:", standardizedProvider);
+  console.log(
+    "[getClientApi] Final Standardized Provider:",
+    standardizedProvider,
+    "| Enum check:",
+    standardizedProvider === ServiceProvider.Bedrock,
+  );
 
   switch (standardizedProvider) {
     case ServiceProvider.Google:
@@ -431,6 +457,18 @@ export function getClientApi(provider: ServiceProvider | string): ClientApi {
       console.log(
         `[getClientApi] Provider '${provider}' (Standardized: '${standardizedProvider}') not matched, returning default GPT.`,
       );
+
+      // Edge browser fallback: check if this is a Bedrock model by name
+      if (
+        typeof provider === "string" &&
+        provider.includes("anthropic.claude")
+      ) {
+        console.log(
+          "[getClientApi] Edge fallback: Detected Bedrock model by name, routing to Bedrock",
+        );
+        return new ClientApi(ModelProvider.Bedrock);
+      }
+
       return new ClientApi(ModelProvider.GPT);
   }
 }

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -367,11 +367,13 @@ export function getClientApi(provider: ServiceProvider | string): ClientApi {
     "| Type:",
     typeof provider,
     "| Browser:",
-    navigator.userAgent.includes("Edge")
-      ? "Edge"
-      : navigator.userAgent.includes("Safari")
-      ? "Safari"
-      : "Other",
+    typeof navigator !== "undefined"
+      ? navigator.userAgent.includes("Edge")
+        ? "Edge"
+        : navigator.userAgent.includes("Safari")
+        ? "Safari"
+        : "Other"
+      : "SSR",
   );
 
   // Standardize the provider name to match Enum case (TitleCase)

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -24,6 +24,7 @@ import { DeepSeekApi } from "./platforms/deepseek";
 import { XAIApi } from "./platforms/xai";
 import { ChatGLMApi } from "./platforms/glm";
 import { SiliconflowApi } from "./platforms/siliconflow";
+import { BedrockApi } from "./platforms/bedrock";
 
 export const ROLES = ["system", "user", "assistant"] as const;
 export type MessageRole = (typeof ROLES)[number];
@@ -172,6 +173,9 @@ export class ClientApi {
         break;
       case ModelProvider.SiliconFlow:
         this.llm = new SiliconflowApi();
+        break;
+      case ModelProvider.Bedrock:
+        this.llm = new BedrockApi();
         break;
       default:
         this.llm = new ChatGPTApi();
@@ -356,7 +360,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
   return headers;
 }
 
-export function getClientApi(provider: ServiceProvider): ClientApi {
+export function getClientApi(provider: ServiceProvider | string): ClientApi {
   switch (provider) {
     case ServiceProvider.Google:
       return new ClientApi(ModelProvider.GeminiPro);
@@ -382,6 +386,9 @@ export function getClientApi(provider: ServiceProvider): ClientApi {
       return new ClientApi(ModelProvider.ChatGLM);
     case ServiceProvider.SiliconFlow:
       return new ClientApi(ModelProvider.SiliconFlow);
+    case ServiceProvider.Bedrock:
+    case "AWS Bedrock":
+      return new ClientApi(ModelProvider.Bedrock);
     default:
       return new ClientApi(ModelProvider.GPT);
   }

--- a/app/client/platforms/bedrock.ts
+++ b/app/client/platforms/bedrock.ts
@@ -31,7 +31,7 @@ export class BedrockApi implements LLMApi {
           messages,
           temperature: modelConfig.temperature,
           stream: !!modelConfig.stream,
-          max_tokens: (modelConfig as any).max_tokens || 4096, // Cast to access max_tokens from ModelConfig
+          max_tokens: (modelConfig as any).max_tokens || 8000, // Cast to access max_tokens from ModelConfig
         }),
         signal: controller.signal,
         headers: getHeaders(), // getHeaders should handle Bedrock (no auth needed)

--- a/app/client/platforms/bedrock.ts
+++ b/app/client/platforms/bedrock.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { ApiPath, Bedrock } from "@/app/constant";
+import { LLMApi, ChatOptions, LLMModel, LLMUsage, SpeechOptions } from "../api";
+import { getHeaders } from "../api";
+import { fetch } from "@/app/utils/stream";
+
+export class BedrockApi implements LLMApi {
+  path(path: string): string {
+    // Route requests to our backend handler
+    const apiPath = `${ApiPath.Bedrock}/${path}`;
+    console.log("[BedrockApi] Constructed API path:", apiPath);
+    return apiPath;
+  }
+
+  async chat(options: ChatOptions) {
+    const messages = options.messages;
+    const modelConfig = options.config;
+
+    const controller = new AbortController();
+    options.onController?.(controller);
+
+    try {
+      const chatPath = this.path(Bedrock.ChatPath);
+      console.log("[BedrockApi] Requesting path:", chatPath);
+
+      const chatPayload = {
+        method: "POST",
+        body: JSON.stringify({
+          model: modelConfig.model,
+          messages,
+          temperature: modelConfig.temperature,
+          stream: !!modelConfig.stream,
+          max_tokens: 4096, // Example: You might want to make this configurable
+        }),
+        signal: controller.signal,
+        headers: getHeaders(), // getHeaders should handle Bedrock (no auth needed)
+      };
+      console.log("[BedrockApi] Request payload (excluding messages):", {
+        model: modelConfig.model,
+        temperature: modelConfig.temperature,
+        stream: !!modelConfig.stream,
+      });
+
+      // Handle stream response
+      if (modelConfig.stream) {
+        const response = await fetch(chatPath, chatPayload);
+        const reader = response.body?.getReader();
+        const decoder = new TextDecoder();
+        let messageBuffer = "";
+
+        if (!reader) {
+          throw new Error("Response body reader is not available");
+        }
+
+        while (true) {
+          // Loop until stream is done
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const text = decoder.decode(value, { stream: true }); // Decode chunk
+          const lines = text.split("\n");
+
+          for (const line of lines) {
+            if (!line.startsWith("data:")) continue;
+            const jsonData = line.substring("data:".length).trim();
+            if (jsonData === "[DONE]") break; // End of stream
+            if (!jsonData) continue;
+
+            try {
+              const data = JSON.parse(jsonData);
+              const content = data.choices?.[0]?.delta?.content ?? "";
+              const finishReason = data.choices?.[0]?.finish_reason;
+
+              if (content) {
+                messageBuffer += content;
+                options.onUpdate?.(messageBuffer, content);
+              }
+              if (finishReason) {
+                // Potentially handle finish reason if needed
+                console.log(
+                  "[BedrockApi] Stream finished with reason:",
+                  finishReason,
+                );
+                break; // Exit inner loop on finish signal within a chunk
+              }
+            } catch (e) {
+              console.error(
+                "[BedrockApi] Error parsing stream chunk:",
+                jsonData,
+                e,
+              );
+            }
+          }
+        }
+        reader.releaseLock(); // Release reader lock
+        options.onFinish(messageBuffer, response);
+      } else {
+        // Handle non-streaming response
+        const response = await fetch(chatPath, chatPayload);
+        if (!response.ok) {
+          const errorBody = await response.text();
+          console.error(
+            "[BedrockApi] Non-stream error response:",
+            response.status,
+            errorBody,
+          );
+          throw new Error(
+            `Request failed with status ${response.status}: ${errorBody}`,
+          );
+        }
+        const responseJson = await response.json();
+        const content = responseJson.choices?.[0]?.message?.content ?? "";
+        options.onFinish(content, response);
+      }
+    } catch (e) {
+      console.error("[BedrockApi] Chat request failed:", e);
+      options.onError?.(e as Error);
+    }
+  }
+
+  async usage(): Promise<LLMUsage> {
+    // Bedrock usage reporting might require separate implementation if available
+    return {
+      used: 0,
+      total: Number.MAX_SAFE_INTEGER, // Indicate no limit or unknown
+    };
+  }
+
+  async models(): Promise<LLMModel[]> {
+    // Fetching models dynamically from Bedrock is complex and usually not needed
+    // Rely on the hardcoded models in constant.ts
+    return [];
+  }
+
+  async speech(options: SpeechOptions): Promise<ArrayBuffer> {
+    // Implement if Bedrock TTS is needed
+    throw new Error("Speech synthesis not supported for Bedrock yet");
+  }
+}

--- a/app/client/platforms/bedrock.ts
+++ b/app/client/platforms/bedrock.ts
@@ -31,7 +31,7 @@ export class BedrockApi implements LLMApi {
           messages,
           temperature: modelConfig.temperature,
           stream: !!modelConfig.stream,
-          max_tokens: 4096, // Example: You might want to make this configurable
+          max_tokens: (modelConfig as any).max_tokens || 4096, // Cast to access max_tokens from ModelConfig
         }),
         signal: controller.signal,
         headers: getHeaders(), // getHeaders should handle Bedrock (no auth needed)

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -244,7 +244,7 @@ export class ChatGPTApi implements LLMApi {
 
       // add max_tokens to vision model
       if (visionModel) {
-        requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
+        requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 8000);
       }
     }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -741,7 +741,7 @@ export function ChatActions(props: {
                 // Only update if we found a valid provider
                 chatStore.updateTargetSession(session, (session) => {
                   session.mask.modelConfig.model = model as ModelType;
-                  session.mask.modelConfig.providerName = targetProvider; // Use the Enum value
+                  session.mask.modelConfig.providerName = targetProvider!; // Use the Enum value (Assert non-null)
                   session.mask.syncGlobalConfig = false;
                   console.log(
                     "[ChatActions] Updated session modelConfig:",

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -720,9 +720,10 @@ export function ChatActions(props: {
                   targetProvider = upperProvider as ServiceProvider;
                 } else {
                   console.error(
-                    `[ChatActions] Unknown provider ID: ${providerId}`,
+                    `[ChatActions] Unknown provider ID: ${providerId}. Falling back to OpenAI.`,
                   );
                   // Handle error or fallback if needed
+                  targetProvider = ServiceProvider.OpenAI; // Fallback for unrecognized provider
                 }
               } else {
                 // Handle case where providerId is missing, maybe default to OpenAI?

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -967,7 +967,9 @@ export function DeleteImageButton(props: { deleteImage: () => void }) {
 }
 
 export function ShortcutKeyModal(props: { onClose: () => void }) {
-  const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const isMac =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().indexOf("MAC") >= 0;
   const shortcuts = [
     {
       title: Locale.Chat.ShortcutKey.newChat,

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -218,7 +218,7 @@ export function ModelConfigList(props: {
           aria-label={Locale.Settings.CompressThreshold.Title}
           type="number"
           min={500}
-          max={4000}
+          max={8000}
           value={props.modelConfig.compressMessageLengthThreshold}
           onChange={(e) =>
             props.updateConfig(

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -163,19 +163,18 @@ export const getServerSideConfig = () => {
   const isXAI = !!process.env.XAI_API_KEY;
   const isChatGLM = !!process.env.CHATGLM_API_KEY;
   const isSiliconFlow = !!process.env.SILICONFLOW_API_KEY;
-  // const apiKeyEnvVar = process.env.OPENAI_API_KEY ?? "";
-  // const apiKeys = apiKeyEnvVar.split(",").map((v) => v.trim());
-  // const randomIndex = Math.floor(Math.random() * apiKeys.length);
-  // const apiKey = apiKeys[randomIndex];
-  // console.log(
-  //   `[Server Config] using ${randomIndex + 1} of ${apiKeys.length} api key`,
-  // );
+
+  const isBedrock =
+    process.env.ENABLE_AWS_BEDROCK === "true" &&
+    !!process.env.AWS_ACCESS_KEY_ID &&
+    !!process.env.AWS_SECRET_ACCESS_KEY &&
+    !!process.env.AWS_REGION;
 
   const allowedWebDavEndpoints = (
     process.env.WHITE_WEBDAV_ENDPOINTS ?? ""
   ).split(",");
 
-  return {
+  const config = {
     baseUrl: process.env.BASE_URL,
     apiKey: getApiKey(process.env.OPENAI_API_KEY),
     openaiOrgId: process.env.OPENAI_ORG_ID,
@@ -246,6 +245,12 @@ export const getServerSideConfig = () => {
     siliconFlowUrl: process.env.SILICONFLOW_URL,
     siliconFlowApiKey: getApiKey(process.env.SILICONFLOW_API_KEY),
 
+    isBedrock,
+    bedrockRegion: process.env.AWS_REGION,
+    bedrockAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    bedrockSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    bedrockEndpoint: process.env.AWS_BEDROCK_ENDPOINT,
+
     gtmId: process.env.GTM_ID,
     gaId: process.env.GA_ID || DEFAULT_GA_ID,
 
@@ -266,4 +271,5 @@ export const getServerSideConfig = () => {
     allowedWebDavEndpoints,
     enableMcp: process.env.ENABLE_MCP === "true",
   };
+  return config;
 };

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -466,6 +466,7 @@ export const VISION_MODEL_REGEXES = [
   /vision/,
   /gpt-4o/,
   /claude-3/,
+  /anthropic\.claude-3/,
   /gemini-1\.5/,
   /gemini-exp/,
   /gemini-2\.0/,
@@ -657,6 +658,24 @@ const siliconflowModels = [
   "Pro/deepseek-ai/DeepSeek-V3",
 ];
 
+const bedrockModels = [
+  "anthropic.claude-3-opus-20240229-v1:0",
+  "anthropic.claude-3-sonnet-20240229-v1:0",
+  "anthropic.claude-3-haiku-20240307-v1:0",
+  "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  "anthropic.claude-3-5-sonnet-20241022-v1:0",
+  "anthropic.claude-3-5-haiku-20241022-v1:0",
+  "anthropic.claude-instant-v1",
+  "amazon.titan-text-express-v1",
+  "amazon.titan-text-lite-v1",
+  "cohere.command-text-v14",
+  "cohere.command-light-text-v14",
+  "ai21.j2-ultra-v1",
+  "ai21.j2-mid-v1",
+  "meta.llama2-13b-chat-v1",
+  "meta.llama2-70b-chat-v1",
+];
+
 let seq = 1000; // 内置的模型序号生成器从1000开始
 export const DEFAULT_MODELS = [
   ...openaiModels.map((name) => ({
@@ -811,6 +830,17 @@ export const DEFAULT_MODELS = [
       providerName: "SiliconFlow",
       providerType: "siliconflow",
       sorted: 14,
+    },
+  })),
+  ...bedrockModels.map((name) => ({
+    name,
+    available: true,
+    sorted: seq++,
+    provider: {
+      id: "bedrock",
+      providerName: "Bedrock",
+      providerType: "bedrock",
+      sorted: 15,
     },
   })),
 ] as const;

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -72,6 +72,7 @@ export enum ApiPath {
   ChatGLM = "/api/chatglm",
   DeepSeek = "/api/deepseek",
   SiliconFlow = "/api/siliconflow",
+  Bedrock = "/api/bedrock",
 }
 
 export enum SlotID {
@@ -130,6 +131,7 @@ export enum ServiceProvider {
   ChatGLM = "ChatGLM",
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
+  Bedrock = "Bedrock",
 }
 
 // Google API safety settings, see https://ai.google.dev/gemini-api/docs/safety-settings
@@ -156,6 +158,7 @@ export enum ModelProvider {
   ChatGLM = "ChatGLM",
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
+  Bedrock = "Bedrock",
 }
 
 export const Stability = {
@@ -264,6 +267,10 @@ export const SiliconFlow = {
   ExampleEndpoint: SILICONFLOW_BASE_URL,
   ChatPath: "v1/chat/completions",
   ListModelPath: "v1/models?&sub_type=chat",
+};
+
+export const Bedrock = {
+  ChatPath: "v1/chat/completions",
 };
 
 export const DEFAULT_INPUT_TEMPLATE = `{{input}}`; // input / time / model / lang

--- a/app/locales/index.ts
+++ b/app/locales/index.ts
@@ -97,6 +97,9 @@ function setItem(key: string, value: string) {
 
 function getLanguage() {
   try {
+    if (typeof navigator === "undefined") {
+      return DEFAULT_LANG;
+    }
     const locale = new Intl.Locale(navigator.language).maximize();
     const region = locale?.region?.toLowerCase();
     // 1. check region code in ALL_LANGS

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,13 @@
 import { Analytics } from "@vercel/analytics/react";
-import { Home } from "./components/home";
 import { getServerSideConfig } from "./config/server";
+import dynamic from "next/dynamic";
+
+const Home = dynamic(
+  () => import("./components/home").then((mod) => ({ default: mod.Home })),
+  {
+    ssr: false,
+  },
+);
 
 const serverConfig = getServerSideConfig();
 

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -867,7 +867,7 @@ export const useChatStore = createPersistStore(
 
         const historyMsgLength = countMessages(toBeSummarizedMsgs);
 
-        if (historyMsgLength > (modelConfig?.max_tokens || 4000)) {
+        if (historyMsgLength > (modelConfig?.max_tokens || 8000)) {
           const n = toBeSummarizedMsgs.length;
           toBeSummarizedMsgs = toBeSummarizedMsgs.slice(
             Math.max(0, n - modelConfig.historyMessageCount),

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -456,7 +456,26 @@ export const useChatStore = createPersistStore(
           ]);
         });
 
-        const api: ClientApi = getClientApi(modelConfig.providerName);
+        // --- 详细日志 (修正版) ---
+        const providerNameFromConfig = modelConfig.providerName;
+        console.log(
+          "[onUserInput] Preparing API call. Provider from config:",
+          providerNameFromConfig,
+          "| Type:",
+          typeof providerNameFromConfig,
+          "| Is Enum value (Bedrock)?:",
+          providerNameFromConfig === ServiceProvider.Bedrock, // 与枚举比较
+          "| Is 'Bedrock' string?:",
+          providerNameFromConfig === "Bedrock", // 与字符串比较
+          "| Model:",
+          modelConfig.model,
+        );
+        // --- 日志结束 ---
+
+        // 使用从配置中获取的 providerName，并提供默认值
+        const api: ClientApi = getClientApi(
+          providerNameFromConfig ?? ServiceProvider.OpenAI,
+        );
         // make request
         api.llm.chat({
           messages: sendMessages,

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -492,7 +492,10 @@ export const useChatStore = createPersistStore(
         );
 
         // Add detailed browser and session logging
-        console.log("[onUserInput] Browser:", navigator.userAgent);
+        console.log(
+          "[onUserInput] Browser:",
+          typeof navigator !== "undefined" ? navigator.userAgent : "SSR",
+        );
         console.log(
           "[onUserInput] Full modelConfig:",
           JSON.stringify(modelConfig, null, 2),

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -68,7 +68,7 @@ export const DEFAULT_CONFIG = {
     providerName: "OpenAI" as ServiceProvider,
     temperature: 0.5,
     top_p: 1,
-    max_tokens: 4000,
+    max_tokens: 8000,
     presence_penalty: 0,
     frequency_penalty: 0,
     sendMemory: true,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -20,8 +20,8 @@ export function trimTopic(topic: string) {
   return (
     topic
       // fix for gemini
-      .replace(/^["“”*]+|["“”*]+$/g, "")
-      .replace(/[，。！？”“"、,.!?*]*$/, "")
+      .replace(/^["""*]+|["""*]+$/g, "")
+      .replace(/[，。！？""""、,.!?*]*$/, "")
   );
 }
 
@@ -114,6 +114,9 @@ export function readFromFile() {
 }
 
 export function isIOS() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
   const userAgent = navigator.userAgent.toLowerCase();
   return /iphone|ipad|ipod/.test(userAgent);
 }

--- a/app/utils/stream.ts
+++ b/app/utils/stream.ts
@@ -69,7 +69,8 @@ export function fetch(url: string, options?: RequestInit): Promise<Response> {
     const headers: Record<string, string> = {
       Accept: "application/json, text/plain, */*",
       "Accept-Language": "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7",
-      "User-Agent": navigator.userAgent,
+      "User-Agent":
+        typeof navigator !== "undefined" ? navigator.userAgent : "NextChat",
     };
     for (const item of new Headers(_headers || {})) {
       headers[item[0]] = item[1];

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:ci": "node --no-warnings --experimental-vm-modules $(yarn bin jest) --ci"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.782.0",
     "@fortaine/fetch-event-source": "^3.0.6",
     "@hello-pangea/dnd": "^16.5.0",
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,423 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-crypto/crc32@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-5.2.0.tgz#cfcc22570949c98c6689cfcbd2d693d36cdae2e1"
+  integrity sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-bedrock-runtime@^3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.782.0.tgz#ec9bf07d2b65ccd8598fa90420d763ff3c487a41"
+  integrity sha512-jG6xHoTpAMlmqEXnW2exBsc9Av/5UpD5R22x1LuwfUZVOMD/F15XuJr/JfzZVG3FJ48H8j9p6hAMY8S4aYdL1A==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/credential-provider-node" "3.782.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.782.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.782.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.782.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.2.0"
+    "@smithy/eventstream-serde-browser" "^4.0.2"
+    "@smithy/eventstream-serde-config-resolver" "^4.1.0"
+    "@smithy/eventstream-serde-node" "^4.0.2"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.0"
+    "@smithy/middleware-retry" "^4.1.0"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.8"
+    "@smithy/util-defaults-mode-node" "^4.0.8"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-stream" "^4.2.0"
+    "@smithy/util-utf8" "^4.0.0"
+    "@types/uuid" "^9.0.1"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
+"@aws-sdk/client-sso@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.782.0.tgz#072cbb23a90ec6fd53145ff75bef8329a857f362"
+  integrity sha512-5GlJBejo8wqMpSSEKb45WE82YxI2k73YuebjLH/eWDNQeE6VI5Bh9lA1YQ7xNkLLH8hIsb0pSfKVuwh0VEzVrg==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.782.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.782.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.782.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.2.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.0"
+    "@smithy/middleware-retry" "^4.1.0"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.8"
+    "@smithy/util-defaults-mode-node" "^4.0.8"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.775.0.tgz#5d22ba78f07c07b48fb4d5b18172b9a896c0cbd0"
+  integrity sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/core" "^3.2.0"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/signature-v4" "^5.0.2"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    fast-xml-parser "4.4.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz#b8c81818f4c62d89b5f04dc410ab9b48e954f22c"
+  integrity sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz#0fbc7f4e6cada37fc9b647de0d7c12a42a44bcc6"
+  integrity sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.782.0.tgz#4ffd90f6b3b6b34d1dabcba875e5d00fc5da23f1"
+  integrity sha512-wd4KdRy2YjLsE4Y7pz00470Iip06GlRHkG4dyLW7/hFMzEO2o7ixswCWp6J2VGZVAX64acknlv2Q0z02ebjmhw==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/credential-provider-env" "3.775.0"
+    "@aws-sdk/credential-provider-http" "3.775.0"
+    "@aws-sdk/credential-provider-process" "3.775.0"
+    "@aws-sdk/credential-provider-sso" "3.782.0"
+    "@aws-sdk/credential-provider-web-identity" "3.782.0"
+    "@aws-sdk/nested-clients" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.782.0.tgz#81a798710d0567b26cd20a105790b49586e68d40"
+  integrity sha512-HZiAF+TCEyKjju9dgysjiPIWgt/+VerGaeEp18mvKLNfgKz1d+/82A2USEpNKTze7v3cMFASx3CvL8yYyF7mJw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.775.0"
+    "@aws-sdk/credential-provider-http" "3.775.0"
+    "@aws-sdk/credential-provider-ini" "3.782.0"
+    "@aws-sdk/credential-provider-process" "3.775.0"
+    "@aws-sdk/credential-provider-sso" "3.782.0"
+    "@aws-sdk/credential-provider-web-identity" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz#7ab90383f12461c5d20546e933924e654660542b"
+  integrity sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.782.0.tgz#f644884cae368204f750c35d8a61a04d77c02674"
+  integrity sha512-1y1ucxTtTIGDSNSNxriQY8msinilhe9gGvQpUDYW9gboyC7WQJPDw66imy258V6osdtdi+xoHzVCbCz3WhosMQ==
+  dependencies:
+    "@aws-sdk/client-sso" "3.782.0"
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/token-providers" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.782.0.tgz#5dbab53a7b49dcf8390d71415855e78b911a4742"
+  integrity sha512-xCna0opVPaueEbJoclj5C6OpDNi0Gynj+4d7tnuXGgQhTHPyAz8ZyClkVqpi5qvHTgxROdUEDxWqEO5jqRHZHQ==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/nested-clients" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-host-header@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz#1bf8160b8f4f96ba30c19f9baa030a6c9bd5f94d"
+  integrity sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-logger@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz#df1909d441cd4bade8d6c7d24c41532808db0e81"
+  integrity sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz#36a40f467754d7c86424d12ef45c05e96ce3475b"
+  integrity sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.782.0.tgz#60e47e365a39cfa64aa81c3c881896face74da45"
+  integrity sha512-i32H2R6IItX+bQ2p4+v2gGO2jA80jQoJO2m1xjU9rYWQW3+ErWy4I5YIuQHTBfb6hSdAHbaRfqPDgbv9J2rjEg==
+  dependencies:
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.782.0"
+    "@smithy/core" "^3.2.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.782.0.tgz#73f56fc4d22e1be342e00b7eba9de4d192521a05"
+  integrity sha512-QOYC8q7luzHFXrP0xYAqBctoPkynjfV0r9dqntFu4/IWMTyC1vlo1UTxFAjIPyclYw92XJyEkVCVg9v/nQnsUA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "3.775.0"
+    "@aws-sdk/middleware-host-header" "3.775.0"
+    "@aws-sdk/middleware-logger" "3.775.0"
+    "@aws-sdk/middleware-recursion-detection" "3.775.0"
+    "@aws-sdk/middleware-user-agent" "3.782.0"
+    "@aws-sdk/region-config-resolver" "3.775.0"
+    "@aws-sdk/types" "3.775.0"
+    "@aws-sdk/util-endpoints" "3.782.0"
+    "@aws-sdk/util-user-agent-browser" "3.775.0"
+    "@aws-sdk/util-user-agent-node" "3.782.0"
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/core" "^3.2.0"
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/hash-node" "^4.0.2"
+    "@smithy/invalid-dependency" "^4.0.2"
+    "@smithy/middleware-content-length" "^4.0.2"
+    "@smithy/middleware-endpoint" "^4.1.0"
+    "@smithy/middleware-retry" "^4.1.0"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-body-length-node" "^4.0.0"
+    "@smithy/util-defaults-mode-browser" "^4.0.8"
+    "@smithy/util-defaults-mode-node" "^4.0.8"
+    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz#592b52498e68501fe46480be3dfb185e949d1eab"
+  integrity sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.782.0.tgz#a6a12f9358f8897f5d1af311da60f90a7d384eac"
+  integrity sha512-4tPuk/3+THPrzKaXW4jE2R67UyGwHLFizZ47pcjJWbhb78IIJAy94vbeqEQ+veS84KF5TXcU7g5jGTXC0D70Wg==
+  dependencies:
+    "@aws-sdk/nested-clients" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@3.775.0", "@aws-sdk/types@^3.222.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.775.0.tgz#09863a9e68c080947db7c3d226d1c56b8f0f5150"
+  integrity sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.782.0.tgz#3b8de42c5fe951337d070432d4a5eba166c07bb7"
+  integrity sha512-/RJOAO7o7HI6lEa4ASbFFLHGU9iPK876BhsVfnl54MvApPVYWQ9sHO0anOUim2S5lQTwd/6ghuH3rFYSq/+rdw==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-endpoints" "^3.0.2"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.723.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz#174551bfdd2eb36d3c16e7023fd7e7ee96ad0fa9"
+  integrity sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@3.775.0":
+  version "3.775.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz#b69a1a5548ccc6db1acb3ec115967593ece927a1"
+  integrity sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==
+  dependencies:
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/types" "^4.2.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@3.782.0":
+  version "3.782.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.782.0.tgz#795f2c22882f1ddbbe83bd324f0ceac1c4b07c89"
+  integrity sha512-dMFkUBgh2Bxuw8fYZQoH/u3H4afQ12VSkzEi//qFiDTwbKYq+u+RYjc8GLDM6JSK1BShMu5AVR7HD4ap1TYUnA==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "3.782.0"
+    "@aws-sdk/types" "3.775.0"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1925,6 +2342,444 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@smithy/abort-controller@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-4.0.2.tgz#36a23e8cc65fc03cacb6afa35dfbfd319c560c6b"
+  integrity sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/config-resolver@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.0.tgz#de1043cbd75f05d99798b0fbcfdaf4b89b0f2f41"
+  integrity sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==
+  dependencies:
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-config-provider" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
+"@smithy/core@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.2.0.tgz#613b15f76eab9a6be396b1d5453b6bc8f22ba99c"
+  integrity sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==
+  dependencies:
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-body-length-browser" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-stream" "^4.2.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz#1ec34a04842fa69996b151a695b027f0486c69a8"
+  integrity sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==
+  dependencies:
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-codec@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-4.0.2.tgz#d4d77699308a3dfeea1b2e87683845f5d8440bdb"
+  integrity sha512-p+f2kLSK7ZrXVfskU/f5dzksKTewZk8pJLPvER3aFHPt76C2MxD9vNatSfLzzQSQB4FNO96RK4PSXfhD1TTeMQ==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-browser@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.2.tgz#876f05491373ab217801c47b802601b8c09388d4"
+  integrity sha512-CepZCDs2xgVUtH7ZZ7oDdZFH8e6Y2zOv8iiX6RhndH69nlojCALSKK+OXwZUgOtUZEUaZ5e1hULVCHYbCn7pug==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-config-resolver@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.0.tgz#4ab7a2575e9041a2df2179bce64619a4e632e4d3"
+  integrity sha512-1PI+WPZ5TWXrfj3CIoKyUycYynYJgZjuQo8U+sphneOtjsgrttYybdqESFReQrdWJ+LKt6NEdbYzmmfDBmjX2A==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-node@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.2.tgz#390306ff79edb0c607705f639d8c5a76caad4bf7"
+  integrity sha512-C5bJ/C6x9ENPMx2cFOirspnF9ZsBVnBMtP6BdPl/qYSuUawdGQ34Lq0dMcf42QTjUZgWGbUIZnz6+zLxJlb9aw==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-universal@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.2.tgz#9f45472fc4fe5fe5f7c22c33d90ec6fc0230d0ae"
+  integrity sha512-St8h9JqzvnbB52FtckiHPN4U/cnXcarMniXRXTKn0r4b4XesZOGiAyUdj1aXbqqn1icSqBlzzUsCl6nPB018ng==
+  dependencies:
+    "@smithy/eventstream-codec" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz#9d3cacf044aa9573ab933f445ab95cddb284813d"
+  integrity sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==
+  dependencies:
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/querystring-builder" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-base64" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/hash-node@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.0.2.tgz#a34fe5a33b067d754ca63302b9791778f003e437"
+  integrity sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/invalid-dependency@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz#e9b1c5e407d795f10a03afba90e37bccdc3e38f7"
+  integrity sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz#55a939029321fec462bcc574890075cd63e94206"
+  integrity sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/middleware-content-length@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz#ff78658e8047ad7038f58478cf8713ee2f6ef647"
+  integrity sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==
+  dependencies:
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-endpoint@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz#cbfe47c5632942c960dbcf71fb02fd0d9985444d"
+  integrity sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==
+  dependencies:
+    "@smithy/core" "^3.2.0"
+    "@smithy/middleware-serde" "^4.0.3"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    "@smithy/url-parser" "^4.0.2"
+    "@smithy/util-middleware" "^4.0.2"
+    tslib "^2.6.2"
+
+"@smithy/middleware-retry@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz#338ac1e025bbc6fd7b008152c4efa8bc0591acc9"
+  integrity sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==
+  dependencies:
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/service-error-classification" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-retry" "^4.0.2"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
+"@smithy/middleware-serde@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz#b90ef1065ad9dc0b54c561fae73c8a5792d145e3"
+  integrity sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-stack@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz#ca7bc3eedc7c1349e2cf94e0dc92a68d681bef18"
+  integrity sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz#017ba626828bced0fa588e795246e5468632f3ef"
+  integrity sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==
+  dependencies:
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/shared-ini-file-loader" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz#aa583d201c1ee968170b65a07f06d633c214b7a1"
+  integrity sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==
+  dependencies:
+    "@smithy/abort-controller" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/querystring-builder" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/property-provider@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-4.0.2.tgz#4572c10415c9d4215f3df1530ba61b0319b17b55"
+  integrity sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.1.0.tgz#ad34e336a95944785185234bebe2ec8dbe266936"
+  integrity sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/querystring-builder@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz#834cea95bf413ab417bf9c166d60fd80d2cb3016"
+  integrity sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-uri-escape" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/querystring-parser@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz#d80c5afb740e12ad8b4d4f58415e402c69712479"
+  integrity sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/service-error-classification@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz#96740ed8be7ac5ad7d6f296d4ddf3f66444b8dcc"
+  integrity sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+
+"@smithy/shared-ini-file-loader@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz#15043f0516fe09ff4b22982bc5f644dc701ebae5"
+  integrity sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.0.2.tgz#363854e946fbc5bc206ff82e79ada5d5c14be640"
+  integrity sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.0.0"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    "@smithy/util-middleware" "^4.0.2"
+    "@smithy/util-uri-escape" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.2.0.tgz#0c64cae4fb5bb4f26386e9b2c33fc9a3c24c9df3"
+  integrity sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==
+  dependencies:
+    "@smithy/core" "^3.2.0"
+    "@smithy/middleware-endpoint" "^4.1.0"
+    "@smithy/middleware-stack" "^4.0.2"
+    "@smithy/protocol-http" "^5.1.0"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-stream" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.2.0.tgz#e7998984cc54b1acbc32e6d4cf982c712e3d26b6"
+  integrity sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/url-parser@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.0.2.tgz#a316f7d8593ffab796348bc5df96237833880713"
+  integrity sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==
+  dependencies:
+    "@smithy/querystring-parser" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.0.0.tgz#8345f1b837e5f636e5f8470c4d1706ae0c6d0358"
+  integrity sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz#965d19109a4b1e5fe7a43f813522cce718036ded"
+  integrity sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz#3db245f6844a9b1e218e30c93305bfe2ffa473b3"
+  integrity sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz#b23b7deb4f3923e84ef50c8b2c5863d0dbf6c0b9"
+  integrity sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-config-provider@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz#e0c7c8124c7fba0b696f78f0bd0ccb060997d45e"
+  integrity sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-browser@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz#77bc4590cdc928901b80f3482e79607a2cbcb150"
+  integrity sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==
+  dependencies:
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.0.8":
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz#123b517efe6434977139b341d1f64b5f1e743aac"
+  integrity sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==
+  dependencies:
+    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/credential-provider-imds" "^4.0.2"
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/property-provider" "^4.0.2"
+    "@smithy/smithy-client" "^4.2.0"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-endpoints@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz#6933a0d6d4a349523ef71ca9540c9c0b222b559e"
+  integrity sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==
+  dependencies:
+    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-hex-encoding@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz#dd449a6452cffb37c5b1807ec2525bb4be551e8d"
+  integrity sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-middleware@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-4.0.2.tgz#272f1249664e27068ef0d5f967a233bf7b77962c"
+  integrity sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==
+  dependencies:
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.0.2.tgz#9b64cf460d63555884e641721d19e3c0abff8ee6"
+  integrity sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==
+  dependencies:
+    "@smithy/service-error-classification" "^4.0.2"
+    "@smithy/types" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.2.0.tgz#85f85516b0042726162bf619caa3358332195652"
+  integrity sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==
+  dependencies:
+    "@smithy/fetch-http-handler" "^5.0.2"
+    "@smithy/node-http-handler" "^4.0.4"
+    "@smithy/types" "^4.2.0"
+    "@smithy/util-base64" "^4.0.0"
+    "@smithy/util-buffer-from" "^4.0.0"
+    "@smithy/util-hex-encoding" "^4.0.0"
+    "@smithy/util-utf8" "^4.0.0"
+    tslib "^2.6.2"
+
+"@smithy/util-uri-escape@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz#a96c160c76f3552458a44d8081fade519d214737"
+  integrity sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.0.0.tgz#09ca2d9965e5849e72e347c130f2a29d5c0c863c"
+  integrity sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.0.0"
+    tslib "^2.6.2"
+
 "@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz#74a5d648bd0347bda99d82409d87b8ca80b9a1ba"
@@ -2432,6 +3287,11 @@
   version "0.0.3"
   resolved "https://registry.npmmirror.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
+"@types/uuid@^9.0.1":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -2983,6 +3843,11 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -4544,6 +5409,13 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-xml-parser@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
+  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
+  dependencies:
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -7879,6 +8751,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strnum@^1.0.5:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
+  integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
+
 style-to-object@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.1.tgz#53cf856f7cf7f172d72939d9679556469ba5de37"
@@ -8337,6 +9214,11 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmmirror.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!--
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->
集成 AWS Bedrock 作为新的 LLM 服务提供商。用户现在可以通过配置 AWS 凭证和区域，在 NextChat 中使用 Bedrock 托管的模型。

主要变更包括：
- 添加 `@aws-sdk/client-bedrock-runtime` 依赖。
- 在 `app/constant.ts` 中添加了 Bedrock 相关的枚举和模型定义。
- 更新了 `app/config/server.ts` 以读取和处理 Bedrock 的环境变量配置。
- 创建了后端 API 处理器 `app/api/bedrock/index.ts`，负责：
    - 调用 AWS Bedrock Runtime API (InvokeModel 和 InvokeModelWithResponseStream)。
    - 处理流式和非流式响应。
    - 将 Bedrock 的响应格式化为 OpenAI 兼容的格式。
- 更新了动态 API 路由 `app/api/[provider]/[...path]/route.ts` 以将 `/api/bedrock/...` 请求分发给 Bedrock 处理器。
- 更新了认证逻辑 `app/api/auth.ts` 以跳过为 Bedrock 请求添加 Authorization 头。
- 创建了前端 Bedrock API 客户端 `app/client/platforms/bedrock.ts`。
- 更新了前端 API 工厂 `app/client/api.ts` (`ClientApi` 构造函数和 `getClientApi`) 以支持 Bedrock 客户端。
- 更新了 `.env.template` 添加 Bedrock 相关配置项，并提供了一个使用 `CUSTOM_MODELS` 重命名 Bedrock 模型名称的示例。

#### 📝 补充信息 | Additional Information

<!--
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
- 此实现目前主要测试了 Bedrock 上的 Anthropic Claude 模型（例如 `us.anthropic.claude-3-5-sonnet-20241022-v2:0`），因为其 API 结构与本项目中的其他 Anthropic 实现类似。理论上支持其他需要类似输入/输出格式的 Bedrock 模型，但可能需要调整 Payload 格式。
- 用户需要在 `.env` 文件中提供有效的 `AWS_ACCESS_KEY_ID`、`AWS_SECRET_ACCESS_KEY` 和 `AWS_REGION`，并将 `ENABLE_AWS_BEDROCK` 设置为 `true` 来启用此功能。
- 可以使用 `CUSTOM_MODELS` 环境变量来添加或重命名 Bedrock 模型，例如：`+us.anthropic.claude-3-5-sonnet-20241022-v2:0@bedrock=sonnet`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refined custom model selection for enhanced precision.
  - Introduced AWS Bedrock support with new configuration options for credentials, region, and endpoints.
  - Added new API capabilities to process Bedrock requests, supporting both streaming and non-streaming interactions.
  - Extended client-side functionality to leverage the new Bedrock service for chat completions, usage reporting, and more.

- **Refactor**
  - Streamlined authentication and provider selection with enhanced logging and error handling.
  - Improved image upload handling with compression and better error management.
  - Enhanced chat input processing with detailed logging and fallback handling for specific model-provider scenarios.

- **Chores**
  - Updated configuration settings and dependencies to incorporate AWS Bedrock integration.
  - Increased default and vision model token limits from 4000 to 8000 for improved capacity.
  - Added runtime environment checks to prevent errors in non-browser contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->