### PR TITLE
Fix provider comparison issue in model comparison

### DIFF
--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -203,7 +203,7 @@ export const useAppConfig = createPersistStore(
       const models = currentState.models.slice();
       state.models.forEach((pModel) => {
         const idx = models.findIndex(
-          (v) => v.name === pModel.name && v.provider === pModel.provider,
+          (v) => v.name === pModel.name && v.provider.id === pModel.provider.id,
         );
         if (idx !== -1) models[idx] = pModel;
         else models.push(pModel);


### PR DESCRIPTION
Fixed an issue where comparing models using the provider object directly resulted in errors. Changed to compare provider.id to ensure the comparison is based on a unique identifier, accurately determining if the models are the same.

If the provider comparison fails, more models will be stored in persistStore. Although this issue is not immediately visible in the frontend due to subsequent processing, it leads to increased memory usage and longer startup times with each page reload.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

##### 修复模型对比中的 provider 对比问题

修复了在对比模型时使用 provider 对象直接比较导致的错误。之前的实现中，provider 是一个对象，直接比较对象会导致对比失败。已修改为对比 provider.id，确保对比的是唯一标识符，从而准确判断是否为同一模型。

因为如果对比 provider 失败，persistStore 中会存入越来越多的 models。虽然由于后续处理问题在前端不会被立即发现，但随着每次重载网页，会消耗更多的内存，并伴随更长的启动时间。

##### 更改内容:

将 v.provider === pModel.provider 修改为 v.provider.id === pModel.provider.id。
影响:
此修复确保模型对比逻辑的准确性，避免因对象直接比较导致的错误，优化了内存使用和启动时间。

##### Fix provider comparison issue in model comparison

Fixed an issue where comparing models using the provider object directly resulted in errors. The previous implementation compared provider as an object, which failed. Changed to compare provider.id to ensure the comparison is based on a unique identifier, accurately determining if the models are the same.

If the provider comparison fails, more models will be stored in persistStore. Although this issue is not immediately visible in the frontend due to subsequent processing, it leads to increased memory usage and longer startup times with each page reload.

##### Changes:

Changed v.provider === pModel.provider to v.provider.id === pModel.provider.id.
Impact:
This fix ensures the accuracy of model comparison logic, preventing errors caused by direct object comparison, and optimizes memory usage and startup time.

