### PR TITLE
fix: Add webpack fallbacks for Node.js core modules in static export

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,8 +21,24 @@ const nextConfig = {
     }
 
     config.resolve.fallback = {
+      ...config.resolve.fallback,
       child_process: false,
+      process: false,
+      path: false,
+      fs: false,
+      os: false,
+      util: false,
+      stream: false,
+      buffer: require.resolve('buffer/'),
+      events: require.resolve('events/'),
     };
+
+    config.plugins.push(
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+        process: 'process/browser',
+      }),
+    );
 
     return config;
   },


### PR DESCRIPTION
This PR fixes the webpack configuration to properly handle Node.js built-in modules during static export builds. The changes include:

- Added proper fallbacks for Node.js core modules (process, child_process, path, fs, os, util, stream)
- Integrated buffer and events polyfills
- Added webpack ProvidePlugin for Buffer and process support

## Related Issue
Fixes #6468

## Changes Made
- Enhanced webpack configuration in `next.config.mjs`
- Added proper module fallbacks for Node.js built-in modules
- Integrated necessary polyfills for browser environment

## Testing
- [ ] Tested static export build
- [ ] Verified no more "UnhandledSchemeError" for node:process and node:child_process
- [ ] Confirmed application builds successfully in export mode