### PR TITLE
 #4839：为桌面端新增网络代理模式设置，

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -86,6 +86,7 @@ import { getClientConfig } from "../config/client";
 import { useSyncStore } from "../store/sync";
 import { nanoid } from "nanoid";
 import { useMaskStore } from "../store/mask";
+import { PROXY_MODES, ProxyMode } from "../store/access";
 import { ProviderType } from "../utils/cloud";
 import { TTSConfigList } from "./tts-config";
 import { RealtimeConfigList } from "./realtime-chat/realtime-config";
@@ -737,6 +738,66 @@ export function Settings() {
         ></input>
       </ListItem>
     );
+  const desktopProxyConfigComponent = clientConfig?.isApp && (
+    <>
+      <ListItem
+        title="Desktop Proxy Mode"
+        subTitle="Choose system, HTTP, or SOCKS5 proxy for desktop requests"
+      >
+        <Select
+          value={accessStore.proxyMode}
+          onChange={(e) =>
+            accessStore.update(
+              (access) => (access.proxyMode = e.target.value as ProxyMode),
+            )
+          }
+        >
+          {PROXY_MODES.map((mode) => (
+            <option value={mode} key={mode}>
+              {mode === "system"
+                ? "System"
+                : mode === "http"
+                ? "HTTP"
+                : "SOCKS5"}
+            </option>
+          ))}
+        </Select>
+      </ListItem>
+
+      {accessStore.proxyMode !== "system" && (
+        <>
+          <ListItem
+            title="Desktop Proxy Host"
+            subTitle="Proxy server hostname or IP address"
+          >
+            <input
+              type="text"
+              value={accessStore.proxyHost}
+              placeholder="127.0.0.1"
+              onChange={(e) =>
+                accessStore.update(
+                  (access) => (access.proxyHost = e.currentTarget.value),
+                )
+              }
+            ></input>
+          </ListItem>
+
+          <ListItem title="Desktop Proxy Port" subTitle="Proxy server port">
+            <input
+              type="text"
+              value={accessStore.proxyPort}
+              placeholder="7890"
+              onChange={(e) =>
+                accessStore.update(
+                  (access) => (access.proxyPort = e.currentTarget.value),
+                )
+              }
+            ></input>
+          </ListItem>
+        </>
+      )}
+    </>
+  );
 
   const openAIConfigComponent = accessStore.provider ===
     ServiceProvider.OpenAI && (
@@ -1459,44 +1520,44 @@ export function Settings() {
     </>
   );
 
-  const ai302ConfigComponent = accessStore.provider === ServiceProvider["302.AI"] && (
+  const ai302ConfigComponent = accessStore.provider ===
+    ServiceProvider["302.AI"] && (
     <>
       <ListItem
-          title={Locale.Settings.Access.AI302.Endpoint.Title}
-          subTitle={
-            Locale.Settings.Access.AI302.Endpoint.SubTitle +
-            AI302.ExampleEndpoint
+        title={Locale.Settings.Access.AI302.Endpoint.Title}
+        subTitle={
+          Locale.Settings.Access.AI302.Endpoint.SubTitle + AI302.ExampleEndpoint
+        }
+      >
+        <input
+          aria-label={Locale.Settings.Access.AI302.Endpoint.Title}
+          type="text"
+          value={accessStore.ai302Url}
+          placeholder={AI302.ExampleEndpoint}
+          onChange={(e) =>
+            accessStore.update(
+              (access) => (access.ai302Url = e.currentTarget.value),
+            )
           }
-        >
-          <input
-            aria-label={Locale.Settings.Access.AI302.Endpoint.Title}
-            type="text"
-            value={accessStore.ai302Url}
-            placeholder={AI302.ExampleEndpoint}
-            onChange={(e) =>
-              accessStore.update(
-                (access) => (access.ai302Url = e.currentTarget.value),
-              )
-            }
-          ></input>
-        </ListItem>
-        <ListItem
-          title={Locale.Settings.Access.AI302.ApiKey.Title}
-          subTitle={Locale.Settings.Access.AI302.ApiKey.SubTitle}
-        >
-          <PasswordInput
-            aria-label={Locale.Settings.Access.AI302.ApiKey.Title}
-            value={accessStore.ai302ApiKey}
-            type="text"
-            placeholder={Locale.Settings.Access.AI302.ApiKey.Placeholder}
-            onChange={(e) => {
-              accessStore.update(
-                (access) => (access.ai302ApiKey = e.currentTarget.value),
-              );
-            }}
-          />
-        </ListItem>
-      </>
+        ></input>
+      </ListItem>
+      <ListItem
+        title={Locale.Settings.Access.AI302.ApiKey.Title}
+        subTitle={Locale.Settings.Access.AI302.ApiKey.SubTitle}
+      >
+        <PasswordInput
+          aria-label={Locale.Settings.Access.AI302.ApiKey.Title}
+          value={accessStore.ai302ApiKey}
+          type="text"
+          placeholder={Locale.Settings.Access.AI302.ApiKey.Placeholder}
+          onChange={(e) => {
+            accessStore.update(
+              (access) => (access.ai302ApiKey = e.currentTarget.value),
+            );
+          }}
+        />
+      </ListItem>
+    </>
   );
 
   return (
@@ -1868,6 +1929,7 @@ export function Settings() {
               )}
             </>
           )}
+          {desktopProxyConfigComponent}
 
           {!shouldHideBalanceQuery && !clientConfig?.isApp ? (
             <ListItem

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -27,6 +27,8 @@ import { DEFAULT_CONFIG } from "./config";
 import { getModelProvider } from "../utils/model";
 
 let fetchState = 0; // 0 not fetch, 1 fetching, 2 done
+export const PROXY_MODES = ["system", "http", "socks5"] as const;
+export type ProxyMode = (typeof PROXY_MODES)[number];
 
 const isApp = getClientConfig()?.buildMode === "export";
 
@@ -138,6 +140,11 @@ const DEFAULT_ACCESS_STATE = {
   // 302.AI
   ai302Url: DEFAULT_AI302_URL,
   ai302ApiKey: "",
+
+  // desktop proxy mode
+  proxyMode: "system" as ProxyMode,
+  proxyHost: "127.0.0.1",
+  proxyPort: "7890",
 
   // server config
   needCode: true,

--- a/app/utils/stream.ts
+++ b/app/utils/stream.ts
@@ -2,6 +2,17 @@
 // see src-tauri/src/stream.rs, and src-tauri/src/main.rs
 // 1. invoke('stream_fetch', {url, method, headers, body}), get response with headers.
 // 2. listen event: `stream-response` multi times to get body
+import { useAccessStore } from "../store/access";
+
+function getDesktopProxyUrl(): string | undefined {
+  const access = useAccessStore.getState();
+  if (access.proxyMode === "system") return undefined;
+  const host = access.proxyHost?.trim().replace(/^(https?|socks5):\/\//i, "");
+  const port = access.proxyPort?.trim() ?? "";
+  if (!host) return undefined;
+  const hp = host.includes(":") ? host : port ? `${host}:${port}` : host;
+  return `${access.proxyMode}://${hp}`;
+}
 
 type ResponseEvent = {
   id: number;
@@ -79,6 +90,7 @@ export function fetch(url: string, options?: RequestInit): Promise<Response> {
         method: method.toUpperCase(),
         url,
         headers,
+        proxy_url: getDesktopProxyUrl(),
         // TODO FormData
         body:
           typeof body === "string"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri = { version = "1.5.4", features = [ "http-all",
 ] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 percent-encoding = "2.3.1"
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", features = ["socks"] }
 futures-util = "0.3.30"
 bytes = "1.7.2"
 

--- a/src-tauri/src/stream.rs
+++ b/src-tauri/src/stream.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::collections::HashMap;
 use futures_util::{StreamExt};
-use reqwest::Client;
+use reqwest::{Client, Proxy};
 use reqwest::header::{HeaderName, HeaderMap};
 
 static REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -38,6 +38,7 @@ pub async fn stream_fetch(
   url: String,
   headers: HashMap<String, String>,
   body: Vec<u8>,
+  proxy_url: Option<String>,
 ) -> Result<StreamResponse, String> {
 
   let event_name = "stream-response";
@@ -54,10 +55,21 @@ pub async fn stream_fetch(
   // println!("headers: {:?}", _headers);
 
   let method = method.parse::<reqwest::Method>().map_err(|err| format!("failed to parse method: {}", err))?;
-  let client = Client::builder()
+  let mut builder = Client::builder()
     .default_headers(_headers)
     .redirect(reqwest::redirect::Policy::limited(3))
-    .connect_timeout(Duration::new(3, 0))
+    .connect_timeout(Duration::new(3, 0));
+
+  if let Some(ref pu) = proxy_url {
+    let pu = pu.trim().to_string();
+    if !pu.is_empty() {
+      let proxy = Proxy::all(&pu)
+        .map_err(|err| format!("failed to parse proxy url: {}", err))?;
+      builder = builder.no_proxy().proxy(proxy);
+    }
+  }
+
+  let client = builder
     .build()
     .map_err(|err| format!("failed to generate client: {}", err))?;
 


### PR DESCRIPTION
close #4839

#### 💻 变更类型 | Change Type

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

本 PR 实现了 #4839：为桌面端新增网络代理模式设置，支持用户在 `system`、`http`、`socks5` 三种模式间切换，解决仅依赖系统代理时无法灵活选择 HTTP/SOCKS5 的问题。

**背景与目标**
- 在桌面环境（尤其 Windows）下，用户经常需要明确指定代理协议类型。
- 原有链路缺少完整的“前端设置 → Tauri 调用 → Rust 请求客户端”代理模式透传能力。

**主要改动**
1. **设置页新增代理模式配置**
   - 新增 `Network Proxy Mode` 选择项：`system / http / socks5`。
   - 在非 `system` 模式下，展示并保存 `Proxy Host`、`Proxy Port` 输入项。
   - 默认值：`127.0.0.1:7890`。

2. **前端状态扩展**
   - 在访问配置中新增：
     - `proxyMode`
     - `proxyHost`
     - `proxyPort`
   - 新增 `PROXY_MODES` 与 `ProxyMode` 类型定义，保证模式值可控。

3. **桌面流式请求链路接入代理 URL**
   - 在 `app/utils/stream.ts` 中根据模式与 host/port 生成 `proxy_url`。
   - `system` 模式不传代理；`http/socks5` 模式构造对应协议 URL。
   - 调用 Tauri `stream_fetch` 时新增 `proxy_url` 参数透传。

4. **Rust 后端支持代理模式**
   - `src-tauri/src/stream.rs` 的 `stream_fetch` 增加 `proxy_url: Option<String>`。
   - 当 `proxy_url` 有效时，通过 `reqwest::Proxy::all(...)` 注入代理。
   - 通过 `no_proxy().proxy(...)` 显式应用用户配置代理。

5. **依赖能力补齐**
   - `src-tauri/Cargo.toml` 中为 `reqwest` 启用 `socks` feature，确保 SOCKS5 可用。

**涉及文件**
- `app/components/settings.tsx`
- `app/store/access.ts`
- `app/utils/stream.ts`
- `src-tauri/src/stream.rs`
- `src-tauri/Cargo.toml`

**最终效果**
- `system`：使用系统默认代理行为（不强制覆盖）。
- `http`：桌面请求走 `http://<host>:<port>`。
- `socks5`：桌面请求走 `socks5://<host>:<port>`。

#### 📝 补充信息 | Additional Information

- 关联 Issue：#4839
- 本次改动范围聚焦于桌面端代理模式能力，不影响非桌面请求链路。