### PR TITLE
docs: highlight NextChat local-first strengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ English / [简体中文](./README_CN.md)
 
 <a href="https://trendshift.io/repositories/5973" target="_blank"><img src="https://trendshift.io/api/badge/repositories/5973" alt="ChatGPTNextWeb%2FChatGPT-Next-Web | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-✨ Light and Fast AI Assistant,with Claude, DeepSeek, GPT4 & Gemini Pro support.
+✨ Local-first, small, and smooth AI assistant with Claude, DeepSeek, GPT-4 & Gemini Pro support.
+
+**Local First. Smallest footprint. Smoothest chat.** NextChat keeps conversations in your browser by default, ships a compact cross-platform client, and stays responsive with fast loading and streaming replies.
 
 [![Saas][Saas-image]][saas-url]
 [![Web][Web-image]][web-url]
@@ -80,12 +82,12 @@ For enterprise inquiries, please contact: **business@nextchat.dev**
 ## Features
 
 - **Deploy for free with one-click** on Vercel in under 1 minute
-- Compact client (~5MB) on Linux/Windows/MacOS, [download it now](https://github.com/Yidadaa/ChatGPT-Next-Web/releases)
+- **Smallest footprint**: compact client (~5MB) on Linux/Windows/MacOS, [download it now](https://github.com/Yidadaa/ChatGPT-Next-Web/releases)
 - Fully compatible with self-deployed LLMs, recommended for use with [RWKV-Runner](https://github.com/josStorer/RWKV-Runner) or [LocalAI](https://github.com/go-skynet/LocalAI)
-- Privacy first, all data is stored locally in the browser
+- **Local first**: all conversations and settings are stored locally in the browser by default
 - Markdown support: LaTex, mermaid, code highlight, etc.
 - Responsive design, dark mode and PWA
-- Fast first screen loading speed (~100kb), support streaming response
+- **Smooth chat**: fast first screen loading speed (~100kb), with streaming responses
 - New in v2: create, share and debug your chat tools with prompt templates (mask)
 - Awesome prompts powered by [awesome-chatgpt-prompts-zh](https://github.com/PlexPt/awesome-chatgpt-prompts-zh) and [awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts)
 - Automatically compresses chat history to support long conversations while also saving your tokens

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,13 +6,21 @@
 
 <h1 align="center">NextChat</h1>
 
-一键免费部署你的私人 ChatGPT 网页应用，支持 Claude, GPT4 & Gemini Pro 模型。
+一键免费部署你的私人 ChatGPT 网页应用，支持 Claude, GPT-4 & Gemini Pro 模型。
+
+**本地优先、小体积、顺滑体验。** NextChat 默认将对话与设置保存在浏览器本地，桌面客户端约 5MB，首屏加载约 100KB，并通过流式响应保持轻快顺滑的聊天体验。
 
 [NextChatAI](https://nextchat.club?utm_source=readme) / [企业版](#%E4%BC%81%E4%B8%9A%E7%89%88) / [演示 Demo](https://chat-gpt-next-web.vercel.app/) / [反馈 Issues](https://github.com/Yidadaa/ChatGPT-Next-Web/issues) / [加入 Discord](https://discord.gg/zrhvHCr79N)
 
 [<img src="https://vercel.com/button" alt="Deploy on Zeabur" height="30">](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FChatGPTNextWeb%2FChatGPT-Next-Web&env=OPENAI_API_KEY&env=CODE&project-name=nextchat&repository-name=NextChat) [<img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" height="30">](https://zeabur.com/templates/ZBUEFA) [<img src="https://gitpod.io/button/open-in-gitpod.svg" alt="Open in Gitpod" height="30">](https://gitpod.io/#https://github.com/Yidadaa/ChatGPT-Next-Web)
 
 </div>
+
+## 核心优势
+
+- **本地优先**：对话与设置默认保存在浏览器本地，方便自托管和隐私保护。
+- **小体积**：首屏加载约 100KB，桌面客户端约 5MB，轻量易部署。
+- **顺滑体验**：支持流式响应、响应式布局、暗色模式和 PWA。
 
 ## Sponsor AI API
 


### PR DESCRIPTION
## Summary

- Highlight NextChat's local-first, small-footprint, and smooth-chat strengths near the top of the English README
- Update the English feature list to call out local storage, compact clients, fast loading, and streaming replies
- Add a Chinese "核心优势" section with the same positioning

Closes #5397

## Validation

- `git diff --check`

