### PR TITLE
fix: trim custom model entries

### DIFF
--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -76,6 +76,7 @@ export function collectModelTable(
   // server custom models
   customModels
     .split(",")
+    .map((v) => v.trim())
     .filter((v) => !!v && v.length > 0)
     .forEach((m) => {
       const available = !m.startsWith("-");

--- a/test/model-available.test.ts
+++ b/test/model-available.test.ts
@@ -77,4 +77,26 @@ describe("isModelNotavailableInServer", () => {
     );
     expect(result).toBe(false);
   });
+
+  test("should trim whitespace around custom model entries", () => {
+    const customModels = `
+      -all,
+      gpt-4,
+      mistral-large
+    `;
+
+    expect(isModelNotavailableInServer(customModels, "gpt-4", "OpenAI")).toBe(
+      false,
+    );
+    expect(
+      isModelNotavailableInServer(customModels, "gpt-3.5-turbo", "OpenAI"),
+    ).toBe(true);
+    expect(
+      isModelNotavailableInServer(
+        customModels,
+        "mistral-large",
+        "mistral-large",
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Trim whitespace around each `CUSTOM_MODELS` entry before parsing it
- Add a regression test covering multi-line, indented custom model lists

Closes #6495

## Validation

- `git diff --check`
- `corepack yarn --version` could not complete because Corepack failed to download Yarn from `registry.yarnpkg.com` in this environment

