### PR TITLE
fix: clarify max output tokens label

### DIFF
--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -570,8 +570,8 @@ const en: LocaleType = {
       SubTitle: "Do not alter this value together with temperature",
     },
     MaxTokens: {
-      Title: "Max Tokens",
-      SubTitle: "Maximum length of input tokens and generated tokens",
+      Title: "Max Output Tokens",
+      SubTitle: "Maximum number of tokens to generate in one response",
     },
     PresencePenalty: {
       Title: "Presence Penalty",


### PR DESCRIPTION
## Summary

- Rename the English setting label from "Max Tokens" to "Max Output Tokens"
- Clarify that the setting controls generated tokens for a single response, not input plus output context length

Closes #5339

## Validation

- `git diff --check`

