### PR TITLE
fix: skip prompt hint navigation while IME is composing

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -326,6 +326,11 @@ export function PromptHints(props: {
       if (noPrompts || e.metaKey || e.altKey || e.ctrlKey) {
         return;
       }
+      // Skip while an IME is composing so Enter confirms the composition and
+      // Arrow keys navigate IME candidates. Mirrors useSubmitHandler above.
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
       // arrow up / down to select prompt
       const changeIndex = (delta: number) => {
         e.stopPropagation();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] fix

#### 🔀 变更说明 | Description of Change

`PromptHints` registers a global `keydown` listener that picks the highlighted hint on Enter and moves the selection with Arrow Up/Down (calling `preventDefault`). The `useSubmitHandler` hook just above it in this file already skips Enter while an IME is composing (`e.keyCode == 229` / `e.nativeEvent.isComposing`, with the comment "Fix Chinese input method 'Enter'"), but this listener has no such guard.

So while the hint list is open (for example after typing `/`, or the full-width `：` command prefix) and a CJK user is mid-composition, the Enter that should confirm the IME composition selects a hint instead, and the Arrow keys used to move through IME candidates get swallowed by `preventDefault`.

This adds the same composition check that `useSubmitHandler` uses, so the listener ignores keydown while the IME is composing. Behavior outside composition is unchanged.

#### 📝 补充信息 | Additional Information

The guard mirrors the existing one in `useSubmitHandler` (same file). I checked that without it an IME-confirming Enter selects a hint and the Arrow keys are preventDefaulted mid-composition, while a normal Enter still selects the highlighted hint. `eslint` reports no new problems and the existing test suite passes.
