### PR TITLE
test: add unit tests for getOperationId

### DIFF
--- a/test/get-operation-id.test.ts
+++ b/test/get-operation-id.test.ts
@@ -1,0 +1,36 @@
+import { getOperationId } from "../app/utils";
+
+describe("getOperationId", () => {
+  test("prefers an explicit operationId when provided", () => {
+    expect(
+      getOperationId({
+        operationId: "listPets",
+        method: "get",
+        path: "/pets",
+      }),
+    ).toBe("listPets");
+  });
+
+  test("derives an id from method and path when operationId is missing", () => {
+    expect(
+      getOperationId({
+        method: "get",
+        path: "/pets/list",
+      }),
+    ).toBe("GET_pets_list");
+  });
+
+  test("uppercases the method and replaces every slash in the path", () => {
+    expect(
+      getOperationId({
+        method: "post",
+        path: "/v1/users/create",
+      }),
+    ).toBe("POST_v1_users_create");
+  });
+
+  test("produces an id matching the allowed pattern ^[a-zA-Z0-9_-]+$", () => {
+    const id = getOperationId({ method: "delete", path: "/a/b/c" });
+    expect(id).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+});


### PR DESCRIPTION
## What

Adds a small, focused unit-test file for the `getOperationId` helper in `app/utils.ts`, which was previously uncovered.

Covered behaviour:
- prefers an explicit `operationId` when provided
- derives an id from `method` + `path` when it is missing
- uppercases the method and replaces every slash in the path
- the produced id matches the allowed pattern `^[a-zA-Z0-9_-]+$`

## Notes

- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.