### PR TITLE
test: add unit tests for safeLocalStorage()

### DIFF
--- a/test/safe-local-storage.test.ts
+++ b/test/safe-local-storage.test.ts
@@ -1,0 +1,40 @@
+import { safeLocalStorage } from "../app/utils";
+
+describe("safeLocalStorage", () => {
+  const storage = safeLocalStorage();
+
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  test("stores and retrieves a value by key", () => {
+    storage.setItem("token", "abc123");
+    expect(storage.getItem("token")).toBe("abc123");
+  });
+
+  test("returns null for a key that was never set", () => {
+    expect(storage.getItem("missing")).toBeNull();
+  });
+
+  test("removes a single item without touching the others", () => {
+    storage.setItem("a", "1");
+    storage.setItem("b", "2");
+    storage.removeItem("a");
+    expect(storage.getItem("a")).toBeNull();
+    expect(storage.getItem("b")).toBe("2");
+  });
+
+  test("clear() empties everything", () => {
+    storage.setItem("a", "1");
+    storage.setItem("b", "2");
+    storage.clear();
+    expect(storage.getItem("a")).toBeNull();
+    expect(storage.getItem("b")).toBeNull();
+  });
+
+  test("overwrites the value when the same key is set twice", () => {
+    storage.setItem("k", "first");
+    storage.setItem("k", "second");
+    expect(storage.getItem("k")).toBe("second");
+  });
+});


### PR DESCRIPTION
## What

Adds a focused unit-test file for the `safeLocalStorage()` wrapper in `app/utils.ts`.

Covered behaviour:
- stores and retrieves a value by key
- returns `null` for a key that was never set
- removes a single item without touching the others
- `clear()` empties everything
- overwrites the value when the same key is set twice

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
