### PR TITLE
test: add unit tests for collect*WithDefaultModel

### DIFF
--- a/test/collect-model-with-default.test.ts
+++ b/test/collect-model-with-default.test.ts
@@ -1,0 +1,52 @@
+import {
+  collectModelTableWithDefaultModel,
+  collectModelsWithDefaultModel,
+} from "../app/utils/model";
+import { DEFAULT_MODELS } from "../app/constant";
+
+describe("collectModelTableWithDefaultModel", () => {
+  test("marks a fully-qualified default model (name@provider) as default", () => {
+    const table = collectModelTableWithDefaultModel(
+      DEFAULT_MODELS,
+      "",
+      "gpt-4@openai",
+    );
+    expect(table["gpt-4@openai"].isDefault).toBe(true);
+  });
+
+  test("marks the first available match when the default omits the provider", () => {
+    const table = collectModelTableWithDefaultModel(
+      DEFAULT_MODELS,
+      "",
+      "gpt-3.5-turbo",
+    );
+    expect(table["gpt-3.5-turbo@openai"].isDefault).toBe(true);
+  });
+
+  test("flags exactly one model as default", () => {
+    const table = collectModelTableWithDefaultModel(
+      DEFAULT_MODELS,
+      "",
+      "gpt-4@openai",
+    );
+    expect(Object.values(table).filter((m) => m.isDefault)).toHaveLength(1);
+  });
+
+  test("leaves every model un-flagged when defaultModel is empty", () => {
+    const table = collectModelTableWithDefaultModel(DEFAULT_MODELS, "", "");
+    expect(Object.values(table).some((m) => m.isDefault)).toBe(false);
+  });
+});
+
+describe("collectModelsWithDefaultModel", () => {
+  test("returns the model list with exactly the chosen default flagged", () => {
+    const models = collectModelsWithDefaultModel(
+      DEFAULT_MODELS,
+      "",
+      "gpt-4@openai",
+    );
+    const defaults = models.filter((m) => m.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].name).toBe("gpt-4");
+  });
+});


### PR DESCRIPTION
## What

Adds a focused unit-test file for `collectModelTableWithDefaultModel()` and `collectModelsWithDefaultModel()` in `app/utils/model.ts`.

Covered behaviour:
- marks a fully-qualified `name@provider` default as default
- marks the first available match when the default omits the provider
- flags exactly one model as default
- leaves everything un-flagged when `defaultModel` is empty
- the model list flags exactly the chosen default

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
