### PR TITLE
test: add unit tests for isModelAvailableInServer

### DIFF
--- a/test/model-available-in-server.test.ts
+++ b/test/model-available-in-server.test.ts
@@ -1,0 +1,33 @@
+import { isModelAvailableInServer } from "../app/utils/model";
+
+describe("isModelAvailableInServer", () => {
+  // NOTE: the helper returns true when a model has been *explicitly disabled*
+  // in the server's custom-model string (available === false), and false
+  // otherwise (including when the model is enabled or unknown).
+
+  test("returns false for a model that is available by default", () => {
+    expect(isModelAvailableInServer("", "gpt-4", "openai")).toBe(false);
+  });
+
+  test("returns true when '-all' disables every model", () => {
+    expect(isModelAvailableInServer("-all", "gpt-4", "openai")).toBe(true);
+  });
+
+  test("returns true when the specific model is disabled", () => {
+    expect(isModelAvailableInServer("-gpt-4@openai", "gpt-4", "openai")).toBe(
+      true,
+    );
+  });
+
+  test("returns false for an unknown model that is not in the table", () => {
+    expect(
+      isModelAvailableInServer("", "totally-unknown-model", "openai"),
+    ).toBe(false);
+  });
+
+  test("a model re-enabled after '-all' is not reported as disabled", () => {
+    expect(
+      isModelAvailableInServer("-all,+gpt-4@openai", "gpt-4", "openai"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a focused unit-test file for `isModelAvailableInServer()` in `app/utils/model.ts`.

Covered behaviour (the helper returns `true` only when a model is *explicitly disabled*):
- returns `false` for a model available by default
- returns `true` when `-all` disables everything
- returns `true` when the specific model is disabled
- returns `false` for an unknown model
- a model re-enabled after `-all` is not reported as disabled

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
