### PR TITLE
test: add unit tests for getBearerToken

### DIFF
--- a/test/get-bearer-token.test.ts
+++ b/test/get-bearer-token.test.ts
@@ -1,0 +1,20 @@
+import { getBearerToken } from "../app/client/api";
+
+describe("getBearerToken", () => {
+  test("wraps the key with a 'Bearer ' prefix by default", () => {
+    expect(getBearerToken("abc")).toBe("Bearer abc");
+  });
+
+  test("omits the prefix when noBearer is true", () => {
+    expect(getBearerToken("abc", true)).toBe("abc");
+  });
+
+  test("trims surrounding whitespace from the key", () => {
+    expect(getBearerToken("  abc  ")).toBe("Bearer abc");
+  });
+
+  test("returns an empty string when the key is empty", () => {
+    expect(getBearerToken("")).toBe("");
+    expect(getBearerToken("", true)).toBe("");
+  });
+});


### PR DESCRIPTION
## What
Adds a focused unit-test file for `getBearerToken()` in `app/client/api.ts`.

Covered behaviour:
- wraps the key with a `Bearer ` prefix by default
- omits the prefix when `noBearer` is true
- trims surrounding whitespace from the key
- returns an empty string when the key is empty

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
