### PR TITLE
test: add unit tests for limitNumber

### DIFF
--- a/test/limit-number.test.ts
+++ b/test/limit-number.test.ts
@@ -1,0 +1,32 @@
+// app/store/config.ts participates in an import cycle, so a static import can
+// hit a temporal-dead-zone error. Load it dynamically in beforeAll instead.
+let limitNumber: (x: number, min: number, max: number, def: number) => number;
+
+beforeAll(async () => {
+  // Warm up the import cycle in a working order before loading the target.
+  await import("../app/client/api");
+  ({ limitNumber } = await import("../app/store/config"));
+});
+
+describe("limitNumber", () => {
+  test("returns the default value for NaN input", () => {
+    expect(limitNumber(NaN, 0, 10, 5)).toBe(5);
+  });
+
+  test("clamps values below the minimum up to the minimum", () => {
+    expect(limitNumber(-3, 0, 10, 5)).toBe(0);
+  });
+
+  test("clamps values above the maximum down to the maximum", () => {
+    expect(limitNumber(99, 0, 10, 5)).toBe(10);
+  });
+
+  test("returns the value unchanged when it is within range", () => {
+    expect(limitNumber(7, 0, 10, 5)).toBe(7);
+  });
+
+  test("treats the min and max boundaries as inclusive", () => {
+    expect(limitNumber(0, 0, 10, 5)).toBe(0);
+    expect(limitNumber(10, 0, 10, 5)).toBe(10);
+  });
+});


### PR DESCRIPTION
## What
Adds a focused unit-test file for `limitNumber()` in `app/store/config.ts`.

Covered behaviour:
- returns the default for `NaN`
- clamps below-min up to min and above-max down to max
- returns in-range values unchanged
- treats min/max boundaries as inclusive

The module participates in an import cycle, so it is loaded dynamically in `beforeAll` (after warming the cycle) — no source changes required.

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
