### PR TITLE
test: add unit tests for ChatCommandPrefix

### DIFF
--- a/test/chat-command-prefix.test.ts
+++ b/test/chat-command-prefix.test.ts
@@ -1,0 +1,28 @@
+// app/command.ts imports app/locales, which participates in an import cycle,
+// so a static import can hit a temporal-dead-zone error. Load it dynamically.
+let ChatCommandPrefix: RegExp;
+
+beforeAll(async () => {
+  // Warm up the import cycle in a working order before loading the target.
+  await import("../app/client/api");
+  ({ ChatCommandPrefix } = await import("../app/command"));
+});
+
+describe("ChatCommandPrefix", () => {
+  test("matches a leading ASCII colon", () => {
+    expect(ChatCommandPrefix.test(":help")).toBe(true);
+  });
+
+  test("matches a leading full-width (CJK) colon", () => {
+    expect(ChatCommandPrefix.test("：help")).toBe(true);
+  });
+
+  test("does not match when the colon is not at the start", () => {
+    expect(ChatCommandPrefix.test("help:me")).toBe(false);
+  });
+
+  test("does not match plain text", () => {
+    expect(ChatCommandPrefix.test("hello")).toBe(false);
+    expect(ChatCommandPrefix.test("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Adds a focused unit-test file for the `ChatCommandPrefix` regex in `app/command.ts`.

Covered behaviour:
- matches a leading ASCII colon `:`
- matches a leading full-width (CJK) colon `：`
- does not match when the colon is not at the start
- does not match plain text / empty input

The module participates in an import cycle, so it is loaded dynamically in `beforeAll` — no source changes required.

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
