### PR TITLE
test: add unit tests for ProsodyOptions (edge-tts)

### DIFF
--- a/test/prosody-options.test.ts
+++ b/test/prosody-options.test.ts
@@ -1,0 +1,27 @@
+import { ProsodyOptions } from "../app/utils/ms_edge_tts";
+
+describe("ProsodyOptions", () => {
+  test("has sensible SSML defaults", () => {
+    const options = new ProsodyOptions();
+    expect(options.pitch).toBe("+0Hz");
+    expect(options.rate).toBe(1.0);
+    expect(options.volume).toBe(100.0);
+  });
+
+  test("allows overriding pitch, rate and volume", () => {
+    const options = new ProsodyOptions();
+    options.pitch = "+2st";
+    options.rate = "+50%";
+    options.volume = 50;
+    expect(options.pitch).toBe("+2st");
+    expect(options.rate).toBe("+50%");
+    expect(options.volume).toBe(50);
+  });
+
+  test("keeps two instances independent", () => {
+    const a = new ProsodyOptions();
+    const b = new ProsodyOptions();
+    a.rate = 2.0;
+    expect(b.rate).toBe(1.0);
+  });
+});


### PR DESCRIPTION
## What
Adds a focused unit-test file for the `ProsodyOptions` class in `app/utils/ms_edge_tts.ts`.

Covered behaviour:
- has sensible SSML defaults (`+0Hz`, `1.0`, `100.0`)
- allows overriding pitch / rate / volume
- keeps two instances independent

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
