### PR TITLE
test: add unit tests for getClientConfig

### DIFF
--- a/test/get-client-config.test.ts
+++ b/test/get-client-config.test.ts
@@ -1,0 +1,25 @@
+import { getClientConfig } from "../app/config/client";
+
+describe("getClientConfig (client side)", () => {
+  afterEach(() => {
+    document
+      .querySelectorAll("meta[name='config']")
+      .forEach((meta) => meta.remove());
+  });
+
+  test("returns an empty object when no config meta tag is present", () => {
+    expect(getClientConfig()).toEqual({});
+  });
+
+  test("parses the JSON payload from the config meta tag", () => {
+    const meta = document.createElement("meta");
+    meta.name = "config";
+    meta.content = JSON.stringify({ buildMode: "standalone", isApp: false });
+    document.head.appendChild(meta);
+
+    expect(getClientConfig()).toEqual({
+      buildMode: "standalone",
+      isApp: false,
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds a focused unit-test file for `getClientConfig()` in `app/config/client.ts` (client-side path).

Covered behaviour:
- returns an empty object when no `config` meta tag is present
- parses the JSON payload from the `config` meta tag

## Notes
- **Additive only** — no existing files are modified or removed.
- `yarn test:ci` passes locally.

Part of a series of small QA-only PRs adding unit coverage for pure helpers.
