### PR TITLE
fix: support custom models not in DEFAULT_MODELS (issue #4221)

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -166,10 +166,12 @@ function fillTemplateWith(input: string, modelConfig: ModelConfig) {
 
   var serviceProvider = "OpenAI";
   if (modelInfo) {
-    // TODO: auto detect the providerName from the modelConfig.model
-
     // Directly use the providerName from the modelInfo
     serviceProvider = modelInfo.provider.providerName;
+  } else if (modelConfig.providerName) {
+    // For custom models not in DEFAULT_MODELS, use the configured providerName
+    // so that {{ServiceProvider}} in templates reflects the actual provider
+    serviceProvider = modelConfig.providerName;
   }
 
   const vars = {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -17,7 +17,8 @@ import {
 import { createPersistStore } from "../utils/store";
 import type { Voice } from "rt-client";
 
-export type ModelType = (typeof DEFAULT_MODELS)[number]["name"];
+// Include `string & {}` to allow custom model names while preserving autocomplete for built-in models
+export type ModelType = (typeof DEFAULT_MODELS)[number]["name"] | (string & {});
 export type TTSModelType = (typeof DEFAULT_TTS_MODELS)[number];
 export type TTSVoiceType = (typeof DEFAULT_TTS_VOICES)[number];
 export type TTSEngineType = (typeof DEFAULT_TTS_ENGINES)[number];

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -254,5 +254,18 @@ export function isModelNotavailableInServer(
     const fullName = `${modelName}@${providerName.toLowerCase()}`;
     if (modelTable?.[fullName]?.available === true) return false;
   }
+
+  // For custom models added without an explicit provider (e.g. just "chatglm3-6b"),
+  // the table entry key is "<modelName>@<modelName>". Check if any available entry
+  // in the custom model table matches this model name, regardless of provider.
+  // This ensures user-defined custom models are never incorrectly blocked.
+  const hasAvailableCustomEntry = Object.values(modelTable).some(
+    (entry) =>
+      entry.name === modelName &&
+      entry.available === true &&
+      entry.provider?.providerType === "custom",
+  );
+  if (hasAvailableCustomEntry) return false;
+
   return true;
 }

--- a/test/custom-model.test.ts
+++ b/test/custom-model.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for custom model support (issue #4221).
+ *
+ * Verifies that models added via the customModels setting (e.g. "chatglm3-6b")
+ * are handled correctly throughout the codebase:
+ *  - collectModelTable builds the right entries
+ *  - isModelNotavailableInServer correctly allows custom models
+ */
+
+import { collectModelTable, isModelNotavailableInServer } from "../app/utils/model";
+import { DEFAULT_MODELS } from "../app/constant";
+
+describe("collectModelTable with custom models", () => {
+  test("adds a custom model with provider derived from model name when no @ given", () => {
+    const table = collectModelTable(DEFAULT_MODELS, "chatglm3-6b");
+    const entry = table["chatglm3-6b@chatglm3-6b"];
+    expect(entry).toBeDefined();
+    expect(entry.name).toBe("chatglm3-6b");
+    expect(entry.available).toBe(true);
+    expect(entry.provider?.providerType).toBe("custom");
+  });
+
+  test("adds a custom model with explicit provider (model@OpenAI format)", () => {
+    const table = collectModelTable(DEFAULT_MODELS, "chatglm3-6b@OpenAI");
+    const entry = table["chatglm3-6b@openai"];
+    expect(entry).toBeDefined();
+    expect(entry.name).toBe("chatglm3-6b");
+    expect(entry.available).toBe(true);
+    expect(entry.provider?.providerType).toBe("custom");
+  });
+
+  test("custom model is marked unavailable when prefixed with -", () => {
+    const table = collectModelTable(DEFAULT_MODELS, "-chatglm3-6b");
+    // Custom model created with available=false
+    const entry = table["chatglm3-6b@chatglm3-6b"];
+    expect(entry).toBeDefined();
+    expect(entry.available).toBe(false);
+  });
+
+  test("custom model with display name alias (model=Alias format)", () => {
+    const table = collectModelTable(DEFAULT_MODELS, "chatglm3-6b=GLM-3");
+    const entry = table["chatglm3-6b@chatglm3-6b"];
+    expect(entry).toBeDefined();
+    expect(entry.displayName).toBe("GLM-3");
+    expect(entry.available).toBe(true);
+  });
+});
+
+describe("isModelNotavailableInServer with custom models", () => {
+  afterEach(() => {
+    delete process.env.DISABLE_GPT4;
+  });
+
+  test("allows a custom model when providerNames includes the model name itself (existing behaviour)", () => {
+    // This is the pattern used in api/common.ts: third provider is the model name
+    const result = isModelNotavailableInServer(
+      "chatglm3-6b",
+      "chatglm3-6b",
+      ["OpenAI", "Azure", "chatglm3-6b"],
+    );
+    expect(result).toBe(false);
+  });
+
+  test("allows a custom model even when providerNames does NOT include the model name (new fallback)", () => {
+    // Custom model added to server customModels without explicit provider.
+    // The request comes in with only standard provider names — the new fallback
+    // should still allow it because the model's providerType is "custom".
+    const result = isModelNotavailableInServer(
+      "chatglm3-6b",
+      "chatglm3-6b",
+      ["OpenAI", "Azure"],
+    );
+    expect(result).toBe(false);
+  });
+
+  test("blocks a model that is not in customModels and not in DEFAULT_MODELS", () => {
+    // No custom model configured — completely unknown model should be blocked
+    // only if customModels is non-empty (the check is skipped when customModels is empty)
+    const result = isModelNotavailableInServer(
+      "-all,gpt-4o-mini", // customModels is set, but chatglm3-6b is not listed
+      "chatglm3-6b",
+      ["OpenAI", "Azure"],
+    );
+    expect(result).toBe(true);
+  });
+
+  test("allows a built-in model when no custom model filter is applied", () => {
+    const result = isModelNotavailableInServer(
+      "",
+      "gpt-4o",
+      "OpenAI",
+    );
+    expect(result).toBe(false);
+  });
+
+  test("custom model added via -all,+model format is allowed", () => {
+    const result = isModelNotavailableInServer(
+      "-all,chatglm3-6b",
+      "chatglm3-6b",
+      ["OpenAI", "Azure", "chatglm3-6b"],
+    );
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
# fix: Support custom models not in DEFAULT_MODELS (issue #4221)

## Problem

When a user adds a custom model name (e.g. `chatglm3-6b`) through the Custom
Model setting and then sends a message, NextChat would fail because:

1. **TypeScript type mismatch** – `ModelType` was narrowly typed as a union of
   literal strings from `DEFAULT_MODELS`. Any custom model name was not part of
   that union, leading to unsafe `as ModelType` casts throughout the code.

2. **Incorrect `{{ServiceProvider}}` in templates** – `fillTemplateWith` looked
   up the model only in `DEFAULT_MODELS`. For custom models the lookup returns
   `undefined`, causing the service provider to always fall back to `"OpenAI"`
   even when a different provider was actually configured.

3. **Server-side model gate could incorrectly block custom models** –
   `isModelNotavailableInServer` checked a fixed list of provider names. If the
   request arrived with only standard provider names (`["OpenAI", "Azure"]`) but
   the model was added as a provider-less custom model (stored under the key
   `<name>@<name>`), the model could still be denied even though the server's
   `CUSTOM_MODEL` env var explicitly listed it.

## Root cause (historical)

An older version of the code contained an explicit throw:
```ts
const modelInfo = DEFAULT_MODELS.find((m) => m.name === modelConfig.model);
if (!modelInfo) {
  throw new Error(`Model ${modelConfig.model} not found in DEFAULT_MODELS array`);
}
```
That check was removed, but related fragilities remained.

## Changes

### `app/store/config.ts`
- Widened `ModelType` from a strict union of built-in model name literals to:
  ```ts
  type ModelType = (typeof DEFAULT_MODELS)[number]["name"] | (string & {});
  ```
  The `string & {}` trick preserves IDE autocomplete for known model names while
  accepting any custom string at the type level — no more unsafe `as ModelType`.

### `app/store/chat.ts`
- `fillTemplateWith`: when the model is not found in `DEFAULT_MODELS`, the
  function now falls back to `modelConfig.providerName` for the
  `{{ServiceProvider}}` template variable, so templates correctly reflect the
  configured provider for user-defined models.

### `app/utils/model.ts`
- `isModelNotavailableInServer`: added a final fallback check — if **any**
  entry in the built model table has `name === modelName`, `available === true`,
  and `providerType === "custom"`, the model is allowed. This ensures that a
  custom model listed in the server's `CUSTOM_MODEL` env var is never blocked
  simply because the incoming request's provider list doesn't match the
  auto-generated `<name>@<name>` key.

### `test/custom-model.test.ts` (new)
- 9 new tests covering:
  - `collectModelTable` with provider-less custom models, explicit-provider
    custom models, disabled custom models, and display-name aliases
  - `isModelNotavailableInServer` for the standard pattern (provider = model
    name), the new fallback (only `["OpenAI", "Azure"]` passed), blocked
    unknown models, and built-in model pass-through

## Testing

```
npx jest test/custom-model.test.ts test/model-available.test.ts test/model-provider.test.ts --no-coverage
# → 21 tests passed, 0 failed
```

## How to reproduce / verify the fix

1. In NextChat Settings → Custom Model, enter `chatglm3-6b` (no `@provider`).
2. Configure a custom OpenAI-compatible endpoint pointing at your local model
   server (e.g. Ollama, vLLM).
3. Select `chatglm3-6b` in the model picker and send a message.
4. The message routes through the OpenAI-compatible client to your endpoint —
   no "not found in DEFAULT_MODELS" error.

## Notes

- Custom models still route through the OpenAI-compatible client by default
  (`getClientApi` falls through to the GPT client for unrecognised providers).
  Users who run a custom model behind an OpenAI-compatible API need to configure
  a custom base URL in Settings → Provider.
- The `vision-model-checker.test.ts` pre-existing ESM/nanoid parse failure is
  unrelated to this PR and was present on `main` before these changes.

---

Branch: `private/issue-4221-custom-model-fix`
Fixes: ChatGPTNextWeb/NextChat#4221
