### PR TITLE
Improve Traditional Chinese coverage for recent UI features

### DIFF
--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -53,8 +53,11 @@ const tw = {
       PinToastAction: "檢視",
       Delete: "刪除",
       Edit: "編輯",
+      FullScreen: "全螢幕",
       RefreshTitle: "重新整理標題",
       RefreshToast: "已傳送重新整理標題請求",
+      Speech: "朗讀",
+      StopSpeech: "停止朗讀",
     },
     Commands: {
       new: "新建聊天",
@@ -62,6 +65,7 @@ const tw = {
       next: "下一個聊天",
       prev: "上一個聊天",
       clear: "清除上下文",
+      fork: "複製對話",
       del: "刪除聊天",
     },
     InputActions: {
@@ -88,6 +92,8 @@ const tw = {
       return inputHints;
     },
     Send: "傳送",
+    StartSpeak: "開始說話",
+    StopSpeak: "停止說話",
     Config: {
       Reset: "重設",
       SaveAs: "另存新檔",
@@ -126,6 +132,10 @@ const tw = {
       Toast: "正在產生截圖",
       Modal: "長按或按右鍵儲存圖片",
     },
+    Artifacts: {
+      Title: "分享 Artifacts",
+      Error: "分享失敗",
+    },
   },
   Select: {
     Search: "查詢訊息",
@@ -150,6 +160,7 @@ const tw = {
   Settings: {
     Title: "設定",
     SubTitle: "設定選項",
+    ShowPassword: "顯示密碼",
 
     Danger: {
       Reset: {
@@ -195,6 +206,8 @@ const tw = {
       IsChecking: "正在檢查更新...",
       FoundUpdate: (x: string) => `發現新版本：${x}`,
       GoToUpdate: "前往更新",
+      Success: "更新成功。",
+      Failed: "更新失敗。",
     },
     SendKey: "傳送鍵",
     Theme: "主題",
@@ -424,6 +437,59 @@ const tw = {
       Title: "頻率懲罰度 (frequency_penalty)",
       SubTitle: "值越大，越有可能降低重複字詞",
     },
+    TTS: {
+      Enable: {
+        Title: "啟用文字轉語音",
+        SubTitle: "啟用文字轉語音服務",
+      },
+      Autoplay: {
+        Title: "啟用自動朗讀",
+        SubTitle: "自動產生並播放語音，須先啟用文字轉語音功能",
+      },
+      Model: "模型",
+      Voice: {
+        Title: "語音",
+        SubTitle: "產生音訊時使用的語音",
+      },
+      Speed: {
+        Title: "語速",
+        SubTitle: "產生語音時使用的速度",
+      },
+      Engine: "TTS 引擎",
+    },
+    Realtime: {
+      Enable: {
+        Title: "即時對話",
+        SubTitle: "啟用即時對話功能",
+      },
+      Provider: {
+        Title: "模型供應商",
+        SubTitle: "切換不同的服務供應商",
+      },
+      Model: {
+        Title: "模型",
+        SubTitle: "選擇模型",
+      },
+      ApiKey: {
+        Title: "API Key",
+        SubTitle: "即時對話所使用的 API Key",
+        Placeholder: "API Key",
+      },
+      Azure: {
+        Endpoint: {
+          Title: "端點位址",
+          SubTitle: "Azure 即時 API 端點位址",
+        },
+        Deployment: {
+          Title: "部署名稱",
+          SubTitle: "Azure 部署名稱",
+        },
+      },
+      Temperature: {
+        Title: "隨機性 (temperature)",
+        SubTitle: "數值越高，回應越隨機",
+      },
+    },
   },
   Store: {
     DefaultTopic: "新的對話",
@@ -452,6 +518,12 @@ const tw = {
     Add: "新增一則",
     Clear: "上下文已清除",
     Revert: "恢復上下文",
+  },
+  Discovery: {
+    Name: "探索",
+  },
+  Mcp: {
+    Name: "MCP",
   },
   Plugin: { Name: "外掛" },
   FineTuned: { Sysmessage: "你是一個助手" },
@@ -488,6 +560,14 @@ const tw = {
       HideContext: {
         Title: "隱藏預設對話",
         SubTitle: "隱藏後預設對話不會出現在聊天介面",
+      },
+      Artifacts: {
+        Title: "啟用 Artifacts",
+        SubTitle: "啟用後可直接呈現 HTML 頁面",
+      },
+      CodeFold: {
+        Title: "啟用程式碼折疊",
+        SubTitle: "啟用後可自動折疊或展開過長的程式碼區塊",
       },
       Share: {
         Title: "分享此角色範本",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] style
- [ ] test
- [ ] docs
- [ ] ci
- [ ] chore
- [ ] build

#### 🔀 变更说明 | Description of Change

Traditional Chinese users currently see English fallback text for several recently added UI features. This PR adds 42 previously missing `tw` locale entries for:

- chat full-screen, speech, and conversation-copy actions
- update success and failure states
- text-to-speech and realtime chat settings
- Artifacts sharing and rendering controls
- CodeFold, Discovery, and MCP labels

The wording follows Taiwanese terminology such as `全螢幕`, `程式碼`, `即時`, and `供應商`. No runtime behavior is changed.

#### 📝 补充信息 | Additional Information

Validation completed:

- `prettier --check app/locales/tw.ts`
- `tsc --noEmit`
- `next lint --file app/locales/tw.ts`
- Jest: 34 suites and 157 tests passed
- locale AST comparison confirms all 42 added paths match existing English locale keys
- `git diff --check`

The remaining untranslated provider, plugin, and image-generation sections are intentionally left for separate reviewable contributions.

AI assistance disclosure: Codex was used to identify missing Traditional Chinese locale paths, compare the English source and UI context, verify AST and placeholder parity, run the listed validation, and help draft this description. I reviewed the final translations and diff.