### PR TITLE
feat: add OrcaRouter as a named model provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -102,6 +102,12 @@ AI302_API_KEY=
 ### 302.AI Api url (optional)
 AI302_URL=
 
+### OrcaRouter Api key (optional)
+ORCAROUTER_API_KEY=
+
+### OrcaRouter Api url (optional)
+ORCAROUTER_URL=
+
 ### xAI (Grok) Api key (optional)
 XAI_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,14 @@ SiliconFlow API URL.
 
 302.AI API URL.
 
+### `ORCAROUTER_API_KEY` (optional)
+
+OrcaRouter API Key.
+
+### `ORCAROUTER_URL` (optional)
+
+OrcaRouter API URL.
+
 ## Requirements
 
 NodeJS >= 18, Docker >= 20

--- a/README_CN.md
+++ b/README_CN.md
@@ -292,6 +292,14 @@ SiliconFlow API URL.
 
 302.AI API URL.
 
+### `ORCAROUTER_API_KEY` (可选)
+
+OrcaRouter API Key。
+
+### `ORCAROUTER_URL` (可选)
+
+OrcaRouter API URL。
+
 ## 开发
 
 点击下方按钮，开始二次开发：

--- a/README_KO.md
+++ b/README_KO.md
@@ -381,6 +381,14 @@ SiliconFlow API URL입니다.
 
 302.AI API URL입니다.
 
+### `ORCAROUTER_API_KEY` (선택 사항)
+
+OrcaRouter API 키입니다.
+
+### `ORCAROUTER_URL` (선택 사항)
+
+OrcaRouter API URL입니다.
+
 ## 요구 사항 (Requirements)
 
 NodeJS >= 18, Docker >= 20

--- a/app/api/[provider]/[...path]/route.ts
+++ b/app/api/[provider]/[...path]/route.ts
@@ -16,6 +16,7 @@ import { handle as xaiHandler } from "../../xai";
 import { handle as chatglmHandler } from "../../glm";
 import { handle as proxyHandler } from "../../proxy";
 import { handle as ai302Handler } from "../../302ai";
+import { handle as orcarouterHandler } from "../../orcarouter";
 
 async function handle(
   req: NextRequest,
@@ -55,6 +56,8 @@ async function handle(
       return openaiHandler(req, { params });
     case ApiPath["302.AI"]:
       return ai302Handler(req, { params });
+    case ApiPath.OrcaRouter:
+      return orcarouterHandler(req, { params });
     default:
       return proxyHandler(req, { params });
   }

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -104,6 +104,9 @@ export function auth(req: NextRequest, modelProvider: ModelProvider) {
       case ModelProvider.SiliconFlow:
         systemApiKey = serverConfig.siliconFlowApiKey;
         break;
+      case ModelProvider.OrcaRouter:
+        systemApiKey = serverConfig.orcarouterApiKey;
+        break;
       case ModelProvider.GPT:
       default:
         if (req.nextUrl.pathname.includes("azure/deployments")) {

--- a/app/api/orcarouter.ts
+++ b/app/api/orcarouter.ts
@@ -1,0 +1,128 @@
+import { getServerSideConfig } from "@/app/config/server";
+import {
+  ORCAROUTER_BASE_URL,
+  ApiPath,
+  ModelProvider,
+  ServiceProvider,
+} from "@/app/constant";
+import { prettyObject } from "@/app/utils/format";
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/app/api/auth";
+import { isModelNotavailableInServer } from "@/app/utils/model";
+
+const serverConfig = getServerSideConfig();
+
+export async function handle(
+  req: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  console.log("[OrcaRouter Route] params ", params);
+
+  if (req.method === "OPTIONS") {
+    return NextResponse.json({ body: "OK" }, { status: 200 });
+  }
+
+  const authResult = auth(req, ModelProvider.OrcaRouter);
+  if (authResult.error) {
+    return NextResponse.json(authResult, {
+      status: 401,
+    });
+  }
+
+  try {
+    const response = await request(req);
+    return response;
+  } catch (e) {
+    console.error("[OrcaRouter] ", e);
+    return NextResponse.json(prettyObject(e));
+  }
+}
+
+async function request(req: NextRequest) {
+  const controller = new AbortController();
+
+  // use base url or just remove the path
+  let path = `${req.nextUrl.pathname}`.replaceAll(ApiPath.OrcaRouter, "");
+
+  let baseUrl = serverConfig.orcarouterUrl || ORCAROUTER_BASE_URL;
+
+  if (!baseUrl.startsWith("http")) {
+    baseUrl = `https://${baseUrl}`;
+  }
+
+  if (baseUrl.endsWith("/")) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+
+  console.log("[Proxy] ", path);
+  console.log("[Base Url]", baseUrl);
+
+  const timeoutId = setTimeout(
+    () => {
+      controller.abort();
+    },
+    10 * 60 * 1000,
+  );
+
+  const fetchUrl = `${baseUrl}${path}`;
+  const fetchOptions: RequestInit = {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: req.headers.get("Authorization") ?? "",
+    },
+    method: req.method,
+    body: req.body,
+    redirect: "manual",
+    // @ts-ignore
+    duplex: "half",
+    signal: controller.signal,
+  };
+
+  // #1815 try to refuse some request to some models
+  if (serverConfig.customModels && req.body) {
+    try {
+      const clonedBody = await req.text();
+      fetchOptions.body = clonedBody;
+
+      const jsonBody = JSON.parse(clonedBody) as { model?: string };
+
+      // not undefined and is false
+      if (
+        isModelNotavailableInServer(
+          serverConfig.customModels,
+          jsonBody?.model as string,
+          ServiceProvider.OrcaRouter as string,
+        )
+      ) {
+        return NextResponse.json(
+          {
+            error: true,
+            message: `you are not allowed to use ${jsonBody?.model} model`,
+          },
+          {
+            status: 403,
+          },
+        );
+      }
+    } catch (e) {
+      console.error(`[OrcaRouter] filter`, e);
+    }
+  }
+  try {
+    const res = await fetch(fetchUrl, fetchOptions);
+
+    // to prevent browser prompt for credentials
+    const newHeaders = new Headers(res.headers);
+    newHeaders.delete("www-authenticate");
+    // to disable nginx buffering
+    newHeaders.set("X-Accel-Buffering", "no");
+
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: newHeaders,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -25,6 +25,7 @@ import { XAIApi } from "./platforms/xai";
 import { ChatGLMApi } from "./platforms/glm";
 import { SiliconflowApi } from "./platforms/siliconflow";
 import { Ai302Api } from "./platforms/ai302";
+import { OrcaRouterApi } from "./platforms/orcarouter";
 
 export const ROLES = ["system", "user", "assistant"] as const;
 export type MessageRole = (typeof ROLES)[number];
@@ -177,6 +178,9 @@ export class ClientApi {
       case ModelProvider["302.AI"]:
         this.llm = new Ai302Api();
         break;
+      case ModelProvider.OrcaRouter:
+        this.llm = new OrcaRouterApi();
+        break;
       default:
         this.llm = new ChatGPTApi();
     }
@@ -270,6 +274,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
     const isSiliconFlow =
       modelConfig.providerName === ServiceProvider.SiliconFlow;
     const isAI302 = modelConfig.providerName === ServiceProvider["302.AI"];
+    const isOrcaRouter = modelConfig.providerName === ServiceProvider.OrcaRouter;
     const isEnabledAccessControl = accessStore.enabledAccessControl();
     const apiKey = isGoogle
       ? accessStore.googleApiKey
@@ -297,6 +302,8 @@ export function getHeaders(ignoreHeaders: boolean = false) {
         : ""
       : isAI302
       ? accessStore.ai302ApiKey
+      : isOrcaRouter
+      ? accessStore.orcarouterApiKey
       : accessStore.openaiApiKey;
     return {
       isGoogle,
@@ -312,6 +319,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
       isChatGLM,
       isSiliconFlow,
       isAI302,
+      isOrcaRouter,
       apiKey,
       isEnabledAccessControl,
     };
@@ -341,6 +349,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
     isChatGLM,
     isSiliconFlow,
     isAI302,
+    isOrcaRouter,
     apiKey,
     isEnabledAccessControl,
   } = getConfig();
@@ -393,6 +402,8 @@ export function getClientApi(provider: ServiceProvider): ClientApi {
       return new ClientApi(ModelProvider.SiliconFlow);
     case ServiceProvider["302.AI"]:
       return new ClientApi(ModelProvider["302.AI"]);
+    case ServiceProvider.OrcaRouter:
+      return new ClientApi(ModelProvider.OrcaRouter);
     default:
       return new ClientApi(ModelProvider.GPT);
   }

--- a/app/client/platforms/orcarouter.ts
+++ b/app/client/platforms/orcarouter.ts
@@ -1,0 +1,285 @@
+"use client";
+
+import {
+  ApiPath,
+  ORCAROUTER_BASE_URL,
+  DEFAULT_MODELS,
+  OrcaRouter,
+} from "@/app/constant";
+import {
+  useAccessStore,
+  useAppConfig,
+  useChatStore,
+  ChatMessageTool,
+  usePluginStore,
+} from "@/app/store";
+import { preProcessImageContent, streamWithThink } from "@/app/utils/chat";
+import {
+  ChatOptions,
+  getHeaders,
+  LLMApi,
+  LLMModel,
+  SpeechOptions,
+} from "../api";
+import { getClientConfig } from "@/app/config/client";
+import {
+  getMessageTextContent,
+  getMessageTextContentWithoutThinking,
+  isVisionModel,
+  getTimeoutMSByModel,
+} from "@/app/utils";
+import { RequestPayload } from "./openai";
+
+import { fetch } from "@/app/utils/stream";
+export interface OrcaRouterListModelResponse {
+  object: string;
+  data: Array<{
+    id: string;
+    object: string;
+    root: string;
+  }>;
+}
+
+export class OrcaRouterApi implements LLMApi {
+  private disableListModels = false;
+
+  path(path: string): string {
+    const accessStore = useAccessStore.getState();
+
+    let baseUrl = "";
+
+    if (accessStore.useCustomConfig) {
+      baseUrl = accessStore.orcarouterUrl;
+    }
+
+    if (baseUrl.length === 0) {
+      const isApp = !!getClientConfig()?.isApp;
+      const apiPath = ApiPath.OrcaRouter;
+      baseUrl = isApp ? ORCAROUTER_BASE_URL : apiPath;
+    }
+
+    if (baseUrl.endsWith("/")) {
+      baseUrl = baseUrl.slice(0, baseUrl.length - 1);
+    }
+    if (
+      !baseUrl.startsWith("http") &&
+      !baseUrl.startsWith(ApiPath.OrcaRouter)
+    ) {
+      baseUrl = "https://" + baseUrl;
+    }
+
+    console.log("[Proxy Endpoint] ", baseUrl, path);
+
+    return [baseUrl, path].join("/");
+  }
+
+  extractMessage(res: any) {
+    return res.choices?.at(0)?.message?.content ?? "";
+  }
+
+  speech(options: SpeechOptions): Promise<ArrayBuffer> {
+    throw new Error("Method not implemented.");
+  }
+
+  async chat(options: ChatOptions) {
+    const visionModel = isVisionModel(options.config.model);
+    const messages: ChatOptions["messages"] = [];
+    for (const v of options.messages) {
+      if (v.role === "assistant") {
+        const content = getMessageTextContentWithoutThinking(v);
+        messages.push({ role: v.role, content });
+      } else {
+        const content = visionModel
+          ? await preProcessImageContent(v.content)
+          : getMessageTextContent(v);
+        messages.push({ role: v.role, content });
+      }
+    }
+
+    const modelConfig = {
+      ...useAppConfig.getState().modelConfig,
+      ...useChatStore.getState().currentSession().mask.modelConfig,
+      ...{
+        model: options.config.model,
+        providerName: options.config.providerName,
+      },
+    };
+
+    const requestPayload: RequestPayload = {
+      messages,
+      stream: options.config.stream,
+      model: modelConfig.model,
+      temperature: modelConfig.temperature,
+      presence_penalty: modelConfig.presence_penalty,
+      frequency_penalty: modelConfig.frequency_penalty,
+      top_p: modelConfig.top_p,
+      // max_tokens: Math.max(modelConfig.max_tokens, 1024),
+      // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
+    };
+
+    console.log("[Request] openai payload: ", requestPayload);
+
+    const shouldStream = !!options.config.stream;
+    const controller = new AbortController();
+    options.onController?.(controller);
+
+    try {
+      const chatPath = this.path(OrcaRouter.ChatPath);
+      const chatPayload = {
+        method: "POST",
+        body: JSON.stringify(requestPayload),
+        signal: controller.signal,
+        headers: getHeaders(),
+      };
+
+      // Use extended timeout for thinking models as they typically require more processing time
+      const requestTimeoutId = setTimeout(
+        () => controller.abort(),
+        getTimeoutMSByModel(options.config.model),
+      );
+
+      if (shouldStream) {
+        const [tools, funcs] = usePluginStore
+          .getState()
+          .getAsTools(
+            useChatStore.getState().currentSession().mask?.plugin || [],
+          );
+        return streamWithThink(
+          chatPath,
+          requestPayload,
+          getHeaders(),
+          tools as any,
+          funcs,
+          controller,
+          // parseSSE
+          (text: string, runTools: ChatMessageTool[]) => {
+            // console.log("parseSSE", text, runTools);
+            const json = JSON.parse(text);
+            const choices = json.choices as Array<{
+              delta: {
+                content: string | null;
+                tool_calls: ChatMessageTool[];
+                reasoning_content: string | null;
+              };
+            }>;
+            const tool_calls = choices[0]?.delta?.tool_calls;
+            if (tool_calls?.length > 0) {
+              const index = tool_calls[0]?.index;
+              const id = tool_calls[0]?.id;
+              const args = tool_calls[0]?.function?.arguments;
+              if (id) {
+                runTools.push({
+                  id,
+                  type: tool_calls[0]?.type,
+                  function: {
+                    name: tool_calls[0]?.function?.name as string,
+                    arguments: args,
+                  },
+                });
+              } else {
+                // @ts-ignore
+                runTools[index]["function"]["arguments"] += args;
+              }
+            }
+            const reasoning = choices[0]?.delta?.reasoning_content;
+            const content = choices[0]?.delta?.content;
+
+            // Skip if both content and reasoning_content are empty or null
+            if (
+              (!reasoning || reasoning.length === 0) &&
+              (!content || content.length === 0)
+            ) {
+              return {
+                isThinking: false,
+                content: "",
+              };
+            }
+
+            if (reasoning && reasoning.length > 0) {
+              return {
+                isThinking: true,
+                content: reasoning,
+              };
+            } else if (content && content.length > 0) {
+              return {
+                isThinking: false,
+                content: content,
+              };
+            }
+
+            return {
+              isThinking: false,
+              content: "",
+            };
+          },
+          // processToolMessage, include tool_calls message and tool call results
+          (
+            requestPayload: RequestPayload,
+            toolCallMessage: any,
+            toolCallResult: any[],
+          ) => {
+            // @ts-ignore
+            requestPayload?.messages?.splice(
+              // @ts-ignore
+              requestPayload?.messages?.length,
+              0,
+              toolCallMessage,
+              ...toolCallResult,
+            );
+          },
+          options,
+        );
+      } else {
+        const res = await fetch(chatPath, chatPayload);
+        clearTimeout(requestTimeoutId);
+
+        const resJson = await res.json();
+        const message = this.extractMessage(resJson);
+        options.onFinish(message, res);
+      }
+    } catch (e) {
+      console.log("[Request] failed to make a chat request", e);
+      options.onError?.(e as Error);
+    }
+  }
+  async usage() {
+    return {
+      used: 0,
+      total: 0,
+    };
+  }
+
+  async models(): Promise<LLMModel[]> {
+    if (this.disableListModels) {
+      return DEFAULT_MODELS.slice();
+    }
+
+    const res = await fetch(this.path(OrcaRouter.ListModelPath), {
+      method: "GET",
+      headers: {
+        ...getHeaders(),
+      },
+    });
+
+    const resJson = (await res.json()) as OrcaRouterListModelResponse;
+    const chatModels = resJson.data;
+    console.log("[Models]", chatModels);
+
+    if (!chatModels) {
+      return [];
+    }
+
+    let seq = 1000; //同 Constant.ts 中的排序保持一致
+    return chatModels.map((m) => ({
+      name: m.id,
+      available: true,
+      sorted: seq++,
+      provider: {
+        id: "orcarouter",
+        providerName: "OrcaRouter",
+        providerType: "orcarouter",
+        sorted: 16,
+      },
+    }));
+  }
+}

--- a/app/components/emoji.tsx
+++ b/app/components/emoji.tsx
@@ -21,6 +21,7 @@ import BotIconGrok from "../icons/llm-icons/grok.svg";
 import BotIconHunyuan from "../icons/llm-icons/hunyuan.svg";
 import BotIconDoubao from "../icons/llm-icons/doubao.svg";
 import BotIconChatglm from "../icons/llm-icons/chatglm.svg";
+import BotIconOrcarouter from "../icons/llm-icons/orcarouter.svg";
 
 export function getEmojiUrl(unified: string, style: EmojiStyle) {
   // Whoever owns this Content Delivery Network (CDN), I am using your CDN to serve emojis
@@ -90,6 +91,8 @@ export function Avatar(props: { model?: ModelType; avatar?: string }) {
       modelName.startsWith("cogvideox-")
     ) {
       LlmIcon = BotIconChatglm;
+    } else if (modelName.includes("orcarouter") || modelName.startsWith("orca-")) {
+      LlmIcon = BotIconOrcarouter;
     }
 
     return (

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -76,6 +76,7 @@ import {
   DeepSeek,
   SiliconFlow,
   AI302,
+  OrcaRouter,
 } from "../constant";
 import { Prompt, SearchService, usePromptStore } from "../store/prompt";
 import { ErrorBoundary } from "./error";
@@ -1499,6 +1500,46 @@ export function Settings() {
       </>
   );
 
+  const orcarouterConfigComponent =
+    accessStore.provider === ServiceProvider.OrcaRouter && (
+      <>
+        <ListItem
+          title={Locale.Settings.Access.OrcaRouter.Endpoint.Title}
+          subTitle={
+            Locale.Settings.Access.OrcaRouter.Endpoint.SubTitle +
+            OrcaRouter.ExampleEndpoint
+          }
+        >
+          <input
+            aria-label={Locale.Settings.Access.OrcaRouter.Endpoint.Title}
+            type="text"
+            value={accessStore.orcarouterUrl}
+            placeholder={OrcaRouter.ExampleEndpoint}
+            onChange={(e) =>
+              accessStore.update(
+                (access) => (access.orcarouterUrl = e.currentTarget.value),
+              )
+            }
+          ></input>
+        </ListItem>
+        <ListItem
+          title={Locale.Settings.Access.OrcaRouter.ApiKey.Title}
+          subTitle={Locale.Settings.Access.OrcaRouter.ApiKey.SubTitle}
+        >
+          <PasswordInput
+            aria-label={Locale.Settings.Access.OrcaRouter.ApiKey.Title}
+            value={accessStore.orcarouterApiKey}
+            type="text"
+            placeholder={Locale.Settings.Access.OrcaRouter.ApiKey.Placeholder}
+            onChange={(e) => {
+              accessStore.update(
+                (access) => (access.orcarouterApiKey = e.currentTarget.value),
+              );
+            }}
+          />
+        </ListItem>
+      </>
+  );
   return (
     <ErrorBoundary>
       <div className="window-header" data-tauri-drag-region>
@@ -1864,6 +1905,7 @@ export function Settings() {
                   {chatglmConfigComponent}
                   {siliconflowConfigComponent}
                   {ai302ConfigComponent}
+                  {orcarouterConfigComponent}
                 </>
               )}
             </>

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -92,6 +92,10 @@ declare global {
       AI302_URL?: string;
       AI302_API_KEY?: string;
 
+      // OrcaRouter only
+      ORCAROUTER_URL?: string;
+      ORCAROUTER_API_KEY?: string;
+
       // custom template for preprocessing user input
       DEFAULT_INPUT_TEMPLATE?: string;
 
@@ -168,6 +172,7 @@ export const getServerSideConfig = () => {
   const isChatGLM = !!process.env.CHATGLM_API_KEY;
   const isSiliconFlow = !!process.env.SILICONFLOW_API_KEY;
   const isAI302 = !!process.env.AI302_API_KEY;
+  const isOrcaRouter = !!process.env.ORCAROUTER_API_KEY;
   // const apiKeyEnvVar = process.env.OPENAI_API_KEY ?? "";
   // const apiKeys = apiKeyEnvVar.split(",").map((v) => v.trim());
   // const randomIndex = Math.floor(Math.random() * apiKeys.length);
@@ -254,6 +259,10 @@ export const getServerSideConfig = () => {
     isAI302,
     ai302Url: process.env.AI302_URL,
     ai302ApiKey: getApiKey(process.env.AI302_API_KEY),
+
+    isOrcaRouter,
+    orcarouterUrl: process.env.ORCAROUTER_URL,
+    orcarouterApiKey: getApiKey(process.env.ORCAROUTER_API_KEY),
 
     gtmId: process.env.GTM_ID,
     gaId: process.env.GA_ID || DEFAULT_GA_ID,

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -37,6 +37,7 @@ export const CHATGLM_BASE_URL = "https://open.bigmodel.cn";
 export const SILICONFLOW_BASE_URL = "https://api.siliconflow.cn";
 
 export const AI302_BASE_URL = "https://api.302.ai";
+export const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai";
 
 export const CACHE_URL_PREFIX = "/api/cache";
 export const UPLOAD_URL = `${CACHE_URL_PREFIX}/upload`;
@@ -75,6 +76,7 @@ export enum ApiPath {
   DeepSeek = "/api/deepseek",
   SiliconFlow = "/api/siliconflow",
   "302.AI" = "/api/302ai",
+  OrcaRouter = "/api/orcarouter",
 }
 
 export enum SlotID {
@@ -134,6 +136,7 @@ export enum ServiceProvider {
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
   "302.AI" = "302.AI",
+  OrcaRouter = "OrcaRouter",
 }
 
 // Google API safety settings, see https://ai.google.dev/gemini-api/docs/safety-settings
@@ -161,6 +164,7 @@ export enum ModelProvider {
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
   "302.AI" = "302.AI",
+  OrcaRouter = "OrcaRouter",
 }
 
 export const Stability = {
@@ -276,6 +280,12 @@ export const AI302 = {
   ChatPath: "v1/chat/completions",
   EmbeddingsPath: "jina/v1/embeddings",
   ListModelPath: "v1/models?llm=1",
+};
+
+export const OrcaRouter = {
+  ExampleEndpoint: ORCAROUTER_BASE_URL,
+  ChatPath: "v1/chat/completions",
+  ListModelPath: "v1/models",
 };
 
 export const DEFAULT_INPUT_TEMPLATE = `{{input}}`; // input / time / model / lang

--- a/app/icons/llm-icons/orcarouter.svg
+++ b/app/icons/llm-icons/orcarouter.svg
@@ -1,0 +1,12 @@
+<svg fill="none" height="1em" style="flex:none;line-height:1" viewBox="0 0 30 30" width="1em" xmlns="http://www.w3.org/2000/svg">
+    <title>OrcaRouter</title>
+    <rect width="30" height="30" fill="#E7F8FF" rx="6"/>
+    <g transform="translate(3, 3)">
+        <path d="M12 5.5v13M5.5 12h13" stroke="#1F2937" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="12" cy="12" r="2.7" fill="#1F2937"/>
+        <circle cx="12" cy="4.8" r="1.9" fill="#1F2937"/>
+        <circle cx="4.8" cy="12" r="1.9" fill="#1F2937"/>
+        <circle cx="19.2" cy="12" r="1.9" fill="#1F2937"/>
+        <circle cx="12" cy="19.2" r="1.9" fill="#1F2937"/>
+    </g>
+</svg>

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -549,6 +549,17 @@ const cn = {
           SubTitle: "样例：",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "接口密钥",
+          SubTitle: "使用自定义OrcaRouter API Key",
+          Placeholder: "OrcaRouter API Key",
+        },
+        Endpoint: {
+          Title: "接口地址",
+          SubTitle: "样例：",
+        },
+      },
     },
 
     Model: "模型 (model)",

--- a/app/locales/da.ts
+++ b/app/locales/da.ts
@@ -528,6 +528,17 @@ const da: PartialLocaleType = {
           SubTitle: "Eksempel: ",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "OrcaRouter API Key",
+          SubTitle: "Brug en custom OrcaRouter API Key",
+          Placeholder: "OrcaRouter API Key",
+        },
+        Endpoint: {
+          Title: "Endpoint-adresse",
+          SubTitle: "Eksempel: ",
+        },
+      },
     },
     Model: "Model",
     CompressModel: {

--- a/app/locales/de.ts
+++ b/app/locales/de.ts
@@ -445,6 +445,17 @@ const de: PartialLocaleType = {
           SubTitle: "Beispiel:",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Schnittstellenschlüssel",
+          SubTitle: "Verwenden Sie einen benutzerdefinierten OrcaRouter API-Schlüssel",
+          Placeholder: "OrcaRouter API-Schlüssel",
+        },
+        Endpoint: {
+          Title: "Endpunktadresse",
+          SubTitle: "Beispiel:",
+        },
+      },
       CustomModel: {
         Title: "Benutzerdefinierter Modellname",
         SubTitle:

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -554,6 +554,17 @@ const en: LocaleType = {
           SubTitle: "Example: ",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "OrcaRouter API Key",
+          SubTitle: "Use a custom OrcaRouter API Key",
+          Placeholder: "OrcaRouter API Key",
+        },
+        Endpoint: {
+          Title: "Endpoint Address",
+          SubTitle: "Example: ",
+        },
+      },
     },
 
     Model: "Model",

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -447,6 +447,17 @@ const es: PartialLocaleType = {
           SubTitle: "Ejemplo:",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Clave de interfaz",
+          SubTitle: "Usa una clave API de OrcaRouter personalizada",
+          Placeholder: "Clave API de OrcaRouter",
+        },
+        Endpoint: {
+          Title: "Dirección del endpoint",
+          SubTitle: "Ejemplo:",
+        },
+      },
       CustomModel: {
         Title: "Nombre del modelo personalizado",
         SubTitle:

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -446,6 +446,17 @@ const fr: PartialLocaleType = {
           SubTitle: "Exemple :",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Clé d'interface",
+          SubTitle: "Utiliser une clé API OrcaRouter personnalisée",
+          Placeholder: "Clé API OrcaRouter",
+        },
+        Endpoint: {
+          Title: "Adresse de l'endpoint",
+          SubTitle: "Exemple :",
+        },
+      },
       CustomModel: {
         Title: "Nom du modèle personnalisé",
         SubTitle:

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -447,6 +447,17 @@ const it: PartialLocaleType = {
           SubTitle: "Esempio:",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Chiave dell'interfaccia",
+          SubTitle: "Utilizza una chiave API OrcaRouter personalizzata",
+          Placeholder: "Chiave API OrcaRouter",
+        },
+        Endpoint: {
+          Title: "Indirizzo dell'interfaccia",
+          SubTitle: "Esempio:",
+        },
+      },
       CustomModel: {
         Title: "Nome del modello personalizzato",
         SubTitle:

--- a/app/locales/ko.ts
+++ b/app/locales/ko.ts
@@ -551,6 +551,17 @@ const ko: PartialLocaleType = {
           SubTitle: "예: ",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "엔드포인트 키",
+          SubTitle: "커스텀 OrcaRouter API 키 사용",
+          Placeholder: "OrcaRouter API 키",
+        },
+        Endpoint: {
+          Title: "엔드포인트 주소",
+          SubTitle: "예: ",
+        },
+      },
     },
 
     Model: "모델 (model)",

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -370,6 +370,17 @@ const pt: PartialLocaleType = {
           SubTitle: "Exemplo: ",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Chave API OrcaRouter",
+          SubTitle: "Use uma chave API OrcaRouter personalizada",
+          Placeholder: "OrcaRouter API Key",
+        },
+        Endpoint: {
+          Title: "Endpoint Address",
+          SubTitle: "Exemplo: ",
+        },
+      },
       CustomModel: {
         Title: "Modelos Personalizados",
         SubTitle: "Opções de modelo personalizado, separados por vírgula",

--- a/app/locales/ru.ts
+++ b/app/locales/ru.ts
@@ -437,6 +437,17 @@ const ru: PartialLocaleType = {
           SubTitle: "Пример:",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Ключ интерфейса",
+          SubTitle: "Использовать пользовательский OrcaRouter API-ключ",
+          Placeholder: "OrcaRouter API-ключ",
+        },
+        Endpoint: {
+          Title: "Адрес интерфейса",
+          SubTitle: "Пример:",
+        },
+      },
       CustomModel: {
         Title: "Название пользовательской модели",
         SubTitle:

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -393,6 +393,17 @@ const tw = {
           SubTitle: "範例：",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "API 金鑰",
+          SubTitle: "使用自訂 OrcaRouter API 金鑰",
+          Placeholder: "OrcaRouter API 金鑰",
+        },
+        Endpoint: {
+          Title: "端點位址",
+          SubTitle: "範例：",
+        },
+      },
       CustomModel: {
         Title: "自訂模型名稱",
         SubTitle: "增加自訂模型可選擇項目，使用英文逗號隔開",

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -433,6 +433,17 @@ const vi: PartialLocaleType = {
           SubTitle: "Ví dụ:",
         },
       },
+      OrcaRouter: {
+        ApiKey: {
+          Title: "Khóa API OrcaRouter",
+          SubTitle: "Sử dụng khóa API OrcaRouter tùy chỉnh",
+          Placeholder: "OrcaRouter API Key",
+        },
+        Endpoint: {
+          Title: "Địa chỉ giao diện",
+          SubTitle: "Ví dụ:",
+        },
+      },
       CustomModel: {
         Title: "Tên mô hình tùy chỉnh",
         SubTitle:

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -18,6 +18,7 @@ import {
   CHATGLM_BASE_URL,
   SILICONFLOW_BASE_URL,
   AI302_BASE_URL,
+  ORCAROUTER_BASE_URL,
 } from "../constant";
 import { getHeaders } from "../client/api";
 import { getClientConfig } from "../config/client";
@@ -61,6 +62,10 @@ const DEFAULT_SILICONFLOW_URL = isApp
   : ApiPath.SiliconFlow;
 
 const DEFAULT_AI302_URL = isApp ? AI302_BASE_URL : ApiPath["302.AI"];
+
+const DEFAULT_ORCAROUTER_URL = isApp
+  ? ORCAROUTER_BASE_URL
+  : ApiPath.OrcaRouter;
 
 const DEFAULT_ACCESS_STATE = {
   accessCode: "",
@@ -138,6 +143,10 @@ const DEFAULT_ACCESS_STATE = {
   // 302.AI
   ai302Url: DEFAULT_AI302_URL,
   ai302ApiKey: "",
+
+  // OrcaRouter
+  orcarouterUrl: DEFAULT_ORCAROUTER_URL,
+  orcarouterApiKey: "",
 
   // server config
   needCode: true,
@@ -226,6 +235,10 @@ export const useAccessStore = createPersistStore(
       return ensure(get(), ["siliconflowApiKey"]);
     },
 
+    isValidOrcaRouter() {
+      return ensure(get(), ["orcarouterApiKey"]);
+    },
+
     isAuthorized() {
       this.fetch();
 
@@ -245,6 +258,7 @@ export const useAccessStore = createPersistStore(
         this.isValidXAI() ||
         this.isValidChatGLM() ||
         this.isValidSiliconFlow() ||
+        this.isValidOrcaRouter() ||
         !this.enabledAccessControl() ||
         (this.enabledAccessControl() && ensure(get(), ["accessCode"]))
       );

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -337,7 +337,8 @@ export function showPlugins(provider: ServiceProvider, model: string) {
     provider == ServiceProvider.OpenAI ||
     provider == ServiceProvider.Azure ||
     provider == ServiceProvider.Moonshot ||
-    provider == ServiceProvider.ChatGLM
+    provider == ServiceProvider.ChatGLM ||
+    provider == ServiceProvider.OrcaRouter
   ) {
     return true;
   }

--- a/test/model-helpers.test.ts
+++ b/test/model-helpers.test.ts
@@ -37,11 +37,14 @@ describe("getTimeoutMSByModel", () => {
 });
 
 describe("showPlugins", () => {
-  test("is enabled for OpenAI, Azure, Moonshot and ChatGLM", () => {
+  test("is enabled for OpenAI, Azure, Moonshot, ChatGLM and OrcaRouter", () => {
     expect(showPlugins(ServiceProvider.OpenAI, "gpt-4")).toBe(true);
     expect(showPlugins(ServiceProvider.Azure, "gpt-4")).toBe(true);
     expect(showPlugins(ServiceProvider.Moonshot, "moonshot-v1-8k")).toBe(true);
     expect(showPlugins(ServiceProvider.ChatGLM, "glm-4")).toBe(true);
+    expect(
+      showPlugins(ServiceProvider.OrcaRouter, "openai/gpt-4o-mini"),
+    ).toBe(true);
   });
 
   test("is enabled for Anthropic except claude-2 models", () => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] feat

#### 🔀 变更说明 | Description of Change

Adds OrcaRouter as a named model provider in NextChat, wired the same way the existing AI302 provider is: server-side route (`/api/orcarouter`), client platform, model picker entry, settings UI, `ORCAROUTER_API_KEY` / `ORCAROUTER_URL` env vars, locale blocks, README docs and a unit test.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

I'm an engineer on the OrcaRouter team.

#### 📝 补充信息 | Additional Information

What this changes:

- `app/constant.ts`: `ORCAROUTER_BASE_URL`, `ApiPath.OrcaRouter`, `ServiceProvider.OrcaRouter`, `ModelProvider.OrcaRouter` and an `OrcaRouter` endpoint object (base `https://api.orcarouter.ai`, `v1/chat/completions`, `v1/models`)
- `app/api/orcarouter.ts` (new): server-side handler mirroring the AI302 handler (base URL from `serverConfig.orcarouterUrl`, model filtering for the OrcaRouter service)
- `app/api/[provider]/[...path]/route.ts`: dispatch `ApiPath.OrcaRouter` to the new handler
- `app/api/auth.ts`: `ORCAROUTER_API_KEY` auth case
- `app/client/platforms/orcarouter.ts` (new): client `LLMApi` implementation (ChatPath / ListModelPath, provider metadata)
- `app/client/api.ts`: provider factory case, key selection from `accessStore.orcarouterApiKey`
- `app/config/server.ts`: `ORCAROUTER_URL` and `ORCAROUTER_API_KEY` env vars
- `app/store/access.ts`: `orcarouterUrl` / `orcarouterApiKey` state and `isValidOrcaRouter`
- `app/components/settings.tsx`: endpoint + API key settings UI (mirrors the AI302 block)
- `app/components/emoji.tsx` + `app/icons/llm-icons/orcarouter.svg` (new): provider icon
- `app/locales/{cn,da,de,en,es,fr,it,ko,pt,ru,tw,vi}.ts`: locale blocks
- `.env.template`, `README.md`, `README_CN.md`, `README_KO.md`: env var docs
- `app/utils.ts`: enable plugins for OrcaRouter
- `test/model-helpers.test.ts`: unit test for `showPlugins(ServiceProvider.OrcaRouter, ...)`

How to use it:

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Pick OrcaRouter as the provider and choose a model id such as `openai/gpt-4-turbo`, `anthropic/claude-sonnet-5` or `deepseek/deepseek-chat`.

Verification:

- `yarn test:ci` (jest): 34 suites, 157 tests passed
- `tsc --noEmit`: clean
- `next build`: exit 0
- Live API against `https://api.orcarouter.ai/v1` with a real key: models list (193 models), non-stream and stream chat completions, tool calling, 401 on bad key, and model-not-found errors all verified
