### PR TITLE
fix(security): harden proxy x-base-url against key leak and SSRF

### DIFF
--- a/app/api/proxy.ts
+++ b/app/api/proxy.ts
@@ -1,6 +1,97 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSideConfig } from "@/app/config/server";
 
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/\.+$/, "");
+}
+
+function parseHttpUrl(raw: string | null): URL | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function isOpenAIApiHost(baseUrl: string | null): boolean {
+  const url = parseHttpUrl(baseUrl);
+  if (!url) return false;
+  return normalizeHostname(url.hostname) === "api.openai.com";
+}
+
+function ipv4Octets(host: string): [number, number, number, number] | null {
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return null;
+  const octets: [number, number, number, number] = [
+    Number(m[1]),
+    Number(m[2]),
+    Number(m[3]),
+    Number(m[4]),
+  ];
+  if (octets.some((n) => n > 255)) return null;
+  return octets;
+}
+
+function isBlockedIPv4(a: number, b: number): boolean {
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const host = normalizeHostname(hostname);
+
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "metadata.google.internal" ||
+    host.endsWith(".internal") ||
+    host === "0.0.0.0"
+  ) {
+    return true;
+  }
+
+  const dotted = ipv4Octets(host);
+  if (dotted) return isBlockedIPv4(dotted[0], dotted[1]);
+
+  if (/^\d+$/.test(host)) {
+    const n = Number(host);
+    if (n >= 0 && n <= 0xffffffff) {
+      return isBlockedIPv4((n >>> 24) & 255, (n >>> 16) & 255);
+    }
+  }
+
+  if (host.includes(":")) {
+    const h = host.replace(/^\[|\]$/g, "");
+    if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+    if (h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd")) {
+      return true;
+    }
+    const mapped = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+    if (mapped) {
+      const d = ipv4Octets(mapped[1]);
+      if (d) return isBlockedIPv4(d[0], d[1]);
+    }
+  }
+
+  return false;
+}
+
+export function isBlockedProxyTarget(baseUrl: string | null): boolean {
+  const url = parseHttpUrl(baseUrl);
+  if (!url) return true;
+  return isBlockedHostname(url.hostname);
+}
+
 export async function handle(
   req: NextRequest,
   { params }: { params: { path: string[] } },
@@ -16,10 +107,17 @@ export async function handle(
   req.nextUrl.searchParams.delete("path");
   req.nextUrl.searchParams.delete("provider");
 
+  const parsedBase = parseHttpUrl(req.headers.get("x-base-url"));
+  if (!parsedBase || isBlockedHostname(parsedBase.hostname)) {
+    return NextResponse.json(
+      { error: true, msg: "x-base-url target is not allowed" },
+      { status: 400 },
+    );
+  }
+
+  const base = `${parsedBase.origin}${parsedBase.pathname}`.replace(/\/$/, "");
   const subpath = params.path.join("/");
-  const fetchUrl = `${req.headers.get(
-    "x-base-url",
-  )}/${subpath}?${req.nextUrl.searchParams.toString()}`;
+  const fetchUrl = `${base}/${subpath}?${req.nextUrl.searchParams.toString()}`;
   const skipHeaders = ["connection", "host", "origin", "referer", "cookie"];
   const headers = new Headers(
     Array.from(req.headers.entries()).filter((item) => {
@@ -33,17 +131,16 @@ export async function handle(
       return true;
     }),
   );
-  // if dalle3 use openai api key
-    const baseUrl = req.headers.get("x-base-url");
-    if (baseUrl?.includes("api.openai.com")) {
-      if (!serverConfig.apiKey) {
-        return NextResponse.json(
-          { error: "OpenAI API key not configured" },
-          { status: 500 },
-        );
-      }
-      headers.set("Authorization", `Bearer ${serverConfig.apiKey}`);
+  // Inject the server OpenAI key only when the hostname is api.openai.com.
+  if (isOpenAIApiHost(parsedBase.origin)) {
+    if (!serverConfig.apiKey) {
+      return NextResponse.json(
+        { error: "OpenAI API key not configured" },
+        { status: 500 },
+      );
     }
+    headers.set("Authorization", `Bearer ${serverConfig.apiKey}`);
+  }
 
   const controller = new AbortController();
   const fetchOptions: RequestInit = {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment node
+ */
+import { isBlockedProxyTarget, isOpenAIApiHost } from "../app/api/proxy";
+
+describe("isOpenAIApiHost (hostname-only OpenAI key injection)", () => {
+  test("injects the server key for the real OpenAI API host", () => {
+    expect(isOpenAIApiHost("https://api.openai.com")).toBe(true);
+    expect(isOpenAIApiHost("https://api.openai.com/v1")).toBe(true);
+    expect(isOpenAIApiHost("https://API.OPENAI.COM")).toBe(true);
+    expect(isOpenAIApiHost("https://api.openai.com.")).toBe(true);
+  });
+
+  test("does not inject when api.openai.com is only a query substring", () => {
+    // Issue #6814 PoC: substring match leaked OPENAI_API_KEY to attacker hosts.
+    expect(isOpenAIApiHost("http://attacker.example?q=api.openai.com")).toBe(
+      false,
+    );
+  });
+
+  test("does not inject when api.openai.com is only a path or fragment", () => {
+    expect(
+      isOpenAIApiHost("http://attacker.example/path/api.openai.com/anything"),
+    ).toBe(false);
+    expect(isOpenAIApiHost("http://attacker.example#api.openai.com")).toBe(
+      false,
+    );
+  });
+
+  test("does not inject for lookalike hostnames", () => {
+    expect(isOpenAIApiHost("http://api.openai.com.evil.example")).toBe(false);
+    expect(isOpenAIApiHost("http://evil-api.openai.com")).toBe(false);
+    expect(isOpenAIApiHost("https://api.openai.com.attacker.example")).toBe(
+      false,
+    );
+  });
+
+  test("does not inject when api.openai.com is userinfo for another host", () => {
+    expect(isOpenAIApiHost("https://api.openai.com@attacker.example")).toBe(
+      false,
+    );
+  });
+
+  test("does not inject for missing or invalid URLs", () => {
+    expect(isOpenAIApiHost(null)).toBe(false);
+    expect(isOpenAIApiHost("")).toBe(false);
+    expect(isOpenAIApiHost("not a url")).toBe(false);
+  });
+});
+
+describe("isBlockedProxyTarget (private / metadata SSRF)", () => {
+  test("blocks cloud metadata and link-local addresses", () => {
+    // Issue #6813 PoC: x-base-url http://169.254.169.254
+    expect(isBlockedProxyTarget("http://169.254.169.254")).toBe(true);
+    expect(
+      isBlockedProxyTarget(
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      ),
+    ).toBe(true);
+    expect(isBlockedProxyTarget("http://metadata.google.internal")).toBe(true);
+  });
+
+  test("blocks loopback and localhost", () => {
+    expect(isBlockedProxyTarget("http://127.0.0.1")).toBe(true);
+    expect(isBlockedProxyTarget("http://127.0.0.2/admin")).toBe(true);
+    expect(isBlockedProxyTarget("http://localhost")).toBe(true);
+    expect(isBlockedProxyTarget("http://localhost:8080/anypath")).toBe(true);
+    expect(isBlockedProxyTarget("http://[::1]/")).toBe(true);
+    expect(isBlockedProxyTarget("http://0.0.0.0")).toBe(true);
+  });
+
+  test("blocks RFC1918 and CGNAT addresses", () => {
+    expect(isBlockedProxyTarget("http://10.0.0.1")).toBe(true);
+    expect(isBlockedProxyTarget("http://192.168.1.1")).toBe(true);
+    expect(isBlockedProxyTarget("http://172.16.0.1")).toBe(true);
+    expect(isBlockedProxyTarget("http://172.31.255.255")).toBe(true);
+    expect(isBlockedProxyTarget("http://100.64.0.1")).toBe(true);
+  });
+
+  test("blocks non-http(s) schemes and missing URLs", () => {
+    expect(isBlockedProxyTarget(null)).toBe(true);
+    expect(isBlockedProxyTarget("")).toBe(true);
+    expect(isBlockedProxyTarget("file:///etc/passwd")).toBe(true);
+    expect(isBlockedProxyTarget("not a url")).toBe(true);
+  });
+
+  test("allows public https hosts used by plugins and OpenAI", () => {
+    expect(isBlockedProxyTarget("https://api.openai.com")).toBe(false);
+    expect(isBlockedProxyTarget("https://api.openai.com/v1")).toBe(false);
+    expect(isBlockedProxyTarget("https://example.com/openapi.json")).toBe(
+      false,
+    );
+    expect(
+      isBlockedProxyTarget("http://attacker.example?q=api.openai.com"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Inject the server `OPENAI_API_KEY` only when the parsed `x-base-url` hostname is exactly `api.openai.com` (not a query/path/fragment/userinfo substring).
- Reject non-http(s) `x-base-url` values and private/metadata/loopback targets (RFC1918, CGNAT, link-local, `169.254.169.254`, `metadata.google.internal`, IPv6 loopback/ULA) with HTTP 400 before fetching.

Fixes #6814
Fixes #6813

## Test plan
- [x] `./node_modules/.bin/jest --ci test/proxy.test.ts` (11 passed)
- [ ] Confirm plugin proxies to public hosts still work
- [ ] Confirm `x-base-url` with `?q=api.openai.com` no longer receives the server key
- [ ] Confirm `x-base-url: http://169.254.169.254` returns 400