### PR TITLE
feat: add configurable OpenAI-compatible speech to text

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ For enterprise inquiries, please contact: **business@nextchat.club**
 - Automatically compresses chat history to support long conversations while also saving your tokens
 - I18n: English, 简体中文, 繁体中文, 日本語, Français, Español, Italiano, Türkçe, Deutsch, Tiếng Việt, Русский, Čeština, 한국어, Indonesia
 
+### Local Speech to Text
+
+NextChat can send an audio file to any OpenAI-compatible transcription server,
+including a self-hosted FunASR or SenseVoice service. In **Settings**, enable
+**Speech to Text**, then enter the server URL, model name, and an optional API
+key. The input toolbar shows a microphone button that adds the transcription to
+the current draft without sending it.
+
+The client sends `POST /v1/audio/transcriptions` as multipart form data with
+`file` and `model`. NextChat does not bundle a Python runtime or model weights;
+the configured transcription server remains responsible for inference and CORS
+access.
+
 <div align="center">
    
 ![主界面](./docs/images/cover.png)

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -34,6 +34,7 @@ import ConfirmIcon from "../icons/confirm.svg";
 import CloseIcon from "../icons/close.svg";
 import CancelIcon from "../icons/cancel.svg";
 import ImageIcon from "../icons/image.svg";
+import VoiceIcon from "../icons/voice.svg";
 
 import LightIcon from "../icons/light.svg";
 import DarkIcon from "../icons/dark.svg";
@@ -118,6 +119,7 @@ import { getClientConfig } from "../config/client";
 import { useAllModels } from "../utils/hooks";
 import { ClientApi, MultimodalContent } from "../client/api";
 import { createTTSPlayer } from "../utils/audio";
+import { transcribeAudio } from "../utils/stt";
 import { MsEdgeTTS, OUTPUT_FORMAT } from "../utils/ms_edge_tts";
 
 import { isEmpty } from "lodash-es";
@@ -501,6 +503,7 @@ export function ChatActions(props: {
   hitBottom: boolean;
   uploading: boolean;
   setShowShortcutKeyModal: React.Dispatch<React.SetStateAction<boolean>>;
+  userInput: string;
   setUserInput: (input: string) => void;
   setShowChatSidePanel: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
@@ -559,6 +562,7 @@ export function ChatActions(props: {
   const [showSizeSelector, setShowSizeSelector] = useState(false);
   const [showQualitySelector, setShowQualitySelector] = useState(false);
   const [showStyleSelector, setShowStyleSelector] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
   const modelSizes = getModelSizes(currentModel);
   const dalle3Qualitys: DalleQuality[] = ["standard", "hd"];
   const dalle3Styles: DalleStyle[] = ["vivid", "natural"];
@@ -568,6 +572,34 @@ export function ChatActions(props: {
   const currentStyle = session.mask.modelConfig?.style ?? "vivid";
 
   const isMobileScreen = useMobileScreen();
+
+  function selectAudioForTranscription() {
+    if (!config.sttConfig.baseUrl.trim()) {
+      showToast(Locale.Settings.STT.BaseUrl.Title);
+      return;
+    }
+
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.accept = "audio/*";
+    fileInput.onchange = async (event: Event) => {
+      const file = (event.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+
+      setIsTranscribing(true);
+      try {
+        const text = await transcribeAudio(file, config.sttConfig);
+        props.setUserInput(
+          `${props.userInput}${props.userInput.trim() ? "\n" : ""}${text}`,
+        );
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : String(error));
+      } finally {
+        setIsTranscribing(false);
+      }
+    };
+    fileInput.click();
+  }
 
   useEffect(() => {
     const show = isVisionModel(currentModel);
@@ -626,6 +658,13 @@ export function ChatActions(props: {
             onClick={props.uploadImage}
             text={Locale.Chat.InputActions.UploadImage}
             icon={props.uploading ? <LoadingButtonIcon /> : <ImageIcon />}
+          />
+        )}
+        {config.sttConfig.enable && (
+          <ChatAction
+            onClick={selectAudioForTranscription}
+            text={Locale.Chat.InputActions.Transcribe}
+            icon={isTranscribing ? <LoadingButtonIcon /> : <VoiceIcon />}
           />
         )}
         <ChatAction
@@ -2065,6 +2104,7 @@ function _Chat() {
                   onSearch("");
                 }}
                 setShowShortcutKeyModal={setShowShortcutKeyModal}
+                userInput={userInput}
                 setUserInput={setUserInput}
                 setShowChatSidePanel={setShowChatSidePanel}
               />

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -88,6 +88,7 @@ import { nanoid } from "nanoid";
 import { useMaskStore } from "../store/mask";
 import { ProviderType } from "../utils/cloud";
 import { TTSConfigList } from "./tts-config";
+import { STTConfigList } from "./stt-config";
 import { RealtimeConfigList } from "./realtime-chat/realtime-config";
 
 function EditPromptModal(props: { id: string; onClose: () => void }) {
@@ -1459,44 +1460,44 @@ export function Settings() {
     </>
   );
 
-  const ai302ConfigComponent = accessStore.provider === ServiceProvider["302.AI"] && (
+  const ai302ConfigComponent = accessStore.provider ===
+    ServiceProvider["302.AI"] && (
     <>
       <ListItem
-          title={Locale.Settings.Access.AI302.Endpoint.Title}
-          subTitle={
-            Locale.Settings.Access.AI302.Endpoint.SubTitle +
-            AI302.ExampleEndpoint
+        title={Locale.Settings.Access.AI302.Endpoint.Title}
+        subTitle={
+          Locale.Settings.Access.AI302.Endpoint.SubTitle + AI302.ExampleEndpoint
+        }
+      >
+        <input
+          aria-label={Locale.Settings.Access.AI302.Endpoint.Title}
+          type="text"
+          value={accessStore.ai302Url}
+          placeholder={AI302.ExampleEndpoint}
+          onChange={(e) =>
+            accessStore.update(
+              (access) => (access.ai302Url = e.currentTarget.value),
+            )
           }
-        >
-          <input
-            aria-label={Locale.Settings.Access.AI302.Endpoint.Title}
-            type="text"
-            value={accessStore.ai302Url}
-            placeholder={AI302.ExampleEndpoint}
-            onChange={(e) =>
-              accessStore.update(
-                (access) => (access.ai302Url = e.currentTarget.value),
-              )
-            }
-          ></input>
-        </ListItem>
-        <ListItem
-          title={Locale.Settings.Access.AI302.ApiKey.Title}
-          subTitle={Locale.Settings.Access.AI302.ApiKey.SubTitle}
-        >
-          <PasswordInput
-            aria-label={Locale.Settings.Access.AI302.ApiKey.Title}
-            value={accessStore.ai302ApiKey}
-            type="text"
-            placeholder={Locale.Settings.Access.AI302.ApiKey.Placeholder}
-            onChange={(e) => {
-              accessStore.update(
-                (access) => (access.ai302ApiKey = e.currentTarget.value),
-              );
-            }}
-          />
-        </ListItem>
-      </>
+        ></input>
+      </ListItem>
+      <ListItem
+        title={Locale.Settings.Access.AI302.ApiKey.Title}
+        subTitle={Locale.Settings.Access.AI302.ApiKey.SubTitle}
+      >
+        <PasswordInput
+          aria-label={Locale.Settings.Access.AI302.ApiKey.Title}
+          value={accessStore.ai302ApiKey}
+          type="text"
+          placeholder={Locale.Settings.Access.AI302.ApiKey.Placeholder}
+          onChange={(e) => {
+            accessStore.update(
+              (access) => (access.ai302ApiKey = e.currentTarget.value),
+            );
+          }}
+        />
+      </ListItem>
+    </>
   );
 
   return (
@@ -1938,6 +1939,16 @@ export function Settings() {
               config.update(
                 (config) => (config.realtimeConfig = realtimeConfig),
               );
+            }}
+          />
+        </List>
+        <List>
+          <STTConfigList
+            sttConfig={config.sttConfig}
+            updateConfig={(updater) => {
+              const sttConfig = { ...config.sttConfig };
+              updater(sttConfig);
+              config.update((config) => (config.sttConfig = sttConfig));
             }}
           />
         </List>

--- a/app/components/stt-config.tsx
+++ b/app/components/stt-config.tsx
@@ -1,0 +1,74 @@
+import { STTConfig } from "../store";
+import Locale from "../locales";
+import { ListItem, PasswordInput } from "./ui-lib";
+
+export function STTConfigList(props: {
+  sttConfig: STTConfig;
+  updateConfig: (updater: (config: STTConfig) => void) => void;
+}) {
+  return (
+    <>
+      <ListItem
+        title={Locale.Settings.STT.Enable.Title}
+        subTitle={Locale.Settings.STT.Enable.SubTitle}
+      >
+        <input
+          type="checkbox"
+          checked={props.sttConfig.enable}
+          onChange={(e) =>
+            props.updateConfig(
+              (config) => (config.enable = e.currentTarget.checked),
+            )
+          }
+        />
+      </ListItem>
+      {props.sttConfig.enable && (
+        <>
+          <ListItem
+            title={Locale.Settings.STT.BaseUrl.Title}
+            subTitle={Locale.Settings.STT.BaseUrl.SubTitle}
+            vertical
+          >
+            <input
+              type="url"
+              value={props.sttConfig.baseUrl}
+              placeholder="http://127.0.0.1:10095"
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) => (config.baseUrl = e.currentTarget.value),
+                )
+              }
+            />
+          </ListItem>
+          <ListItem title={Locale.Settings.STT.Model.Title} vertical>
+            <input
+              type="text"
+              value={props.sttConfig.model}
+              placeholder="FunAudioLLM/Fun-ASR-Nano-2512"
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) => (config.model = e.currentTarget.value),
+                )
+              }
+            />
+          </ListItem>
+          <ListItem
+            title={Locale.Settings.STT.ApiKey.Title}
+            subTitle={Locale.Settings.STT.ApiKey.SubTitle}
+            vertical
+          >
+            <PasswordInput
+              value={props.sttConfig.apiKey}
+              placeholder={Locale.Settings.STT.ApiKey.Placeholder}
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) => (config.apiKey = e.currentTarget.value),
+                )
+              }
+            />
+          </ListItem>
+        </>
+      )}
+    </>
+  );
+}

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -81,6 +81,7 @@ const cn = {
       Clear: "清除聊天",
       Settings: "对话设置",
       UploadImage: "上传图片",
+      Transcribe: "语音转文字",
     },
     Rename: "重命名对话",
     Typing: "正在输入…",
@@ -594,6 +595,24 @@ const cn = {
       Speed: {
         Title: "速度",
         SubTitle: "生成语音的速度",
+      },
+    },
+    STT: {
+      Enable: {
+        Title: "启用语音转文字",
+        SubTitle: "使用 OpenAI 兼容的 FunASR、SenseVoice 或其他转写服务",
+      },
+      BaseUrl: {
+        Title: "转写服务地址",
+        SubTitle: "服务地址；NextChat 会请求 /v1/audio/transcriptions",
+      },
+      Model: {
+        Title: "转写模型",
+      },
+      ApiKey: {
+        Title: "API Key",
+        SubTitle: "可选；仅发送至配置的转写服务",
+        Placeholder: "可选 API Key",
       },
     },
     Realtime: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -82,6 +82,7 @@ const en: LocaleType = {
       Clear: "Clear Context",
       Settings: "Settings",
       UploadImage: "Upload Images",
+      Transcribe: "Speech to Text",
     },
     Rename: "Rename Chat",
     Typing: "Typing…",
@@ -603,6 +604,25 @@ const en: LocaleType = {
         SubTitle: "The speed of the generated audio",
       },
       Engine: "TTS Engine",
+    },
+    STT: {
+      Enable: {
+        Title: "Enable Speech to Text",
+        SubTitle:
+          "Use an OpenAI-compatible FunASR, SenseVoice, or other transcription service",
+      },
+      BaseUrl: {
+        Title: "Transcription Server URL",
+        SubTitle: "Server URL; NextChat requests /v1/audio/transcriptions",
+      },
+      Model: {
+        Title: "Transcription Model",
+      },
+      ApiKey: {
+        Title: "API Key",
+        SubTitle: "Optional; sent only to the configured transcription server",
+        Placeholder: "Optional API key",
+      },
     },
     Realtime: {
       Enable: {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -92,6 +92,13 @@ export const DEFAULT_CONFIG = {
     speed: 1.0,
   },
 
+  sttConfig: {
+    enable: false,
+    baseUrl: "",
+    model: "FunAudioLLM/Fun-ASR-Nano-2512",
+    apiKey: "",
+  },
+
   realtimeConfig: {
     enable: false,
     provider: "OpenAI" as ServiceProvider,
@@ -110,6 +117,7 @@ export type ChatConfig = typeof DEFAULT_CONFIG;
 
 export type ModelConfig = ChatConfig["modelConfig"];
 export type TTSConfig = ChatConfig["ttsConfig"];
+export type STTConfig = ChatConfig["sttConfig"];
 export type RealtimeConfig = ChatConfig["realtimeConfig"];
 
 export function limitNumber(

--- a/app/utils/stt.ts
+++ b/app/utils/stt.ts
@@ -1,0 +1,54 @@
+export function getTranscriptionEndpoint(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/v1$/, "");
+
+  return `${normalizedBaseUrl}/v1/audio/transcriptions`;
+}
+
+export function getTranscriptionHeaders(
+  apiKey: string,
+): Record<string, string> {
+  const token = apiKey.trim();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export type TranscriptionConfig = {
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+};
+
+type TranscriptionResponse = {
+  text?: string;
+  error?: { message?: string };
+};
+
+export async function transcribeAudio(
+  audio: File,
+  config: TranscriptionConfig,
+  request: typeof fetch = fetch,
+): Promise<string> {
+  const form = new FormData();
+  form.set("file", audio);
+
+  const model = config.model.trim();
+  if (model) form.set("model", model);
+
+  const response = await request(getTranscriptionEndpoint(config.baseUrl), {
+    method: "POST",
+    headers: getTranscriptionHeaders(config.apiKey),
+    body: form,
+  });
+  const payload = (await response.json()) as TranscriptionResponse;
+
+  if (!response.ok) {
+    throw new Error(payload.error?.message ?? "Transcription request failed");
+  }
+  if (typeof payload.text !== "string") {
+    throw new Error("Transcription response did not include text");
+  }
+
+  return payload.text;
+}

--- a/test/stt.test.ts
+++ b/test/stt.test.ts
@@ -1,0 +1,53 @@
+import { jest } from "@jest/globals";
+
+import {
+  getTranscriptionEndpoint,
+  getTranscriptionHeaders,
+  transcribeAudio,
+} from "../app/utils/stt";
+
+describe("FunASR-compatible transcription requests", () => {
+  test("normalizes a server base URL to the OpenAI transcription endpoint", () => {
+    expect(getTranscriptionEndpoint("http://127.0.0.1:10095/")).toBe(
+      "http://127.0.0.1:10095/v1/audio/transcriptions",
+    );
+    expect(getTranscriptionEndpoint("http://127.0.0.1:10095/v1")).toBe(
+      "http://127.0.0.1:10095/v1/audio/transcriptions",
+    );
+  });
+
+  test("only emits bearer authorization when the user configured a token", () => {
+    expect(getTranscriptionHeaders("")).toEqual({});
+    expect(getTranscriptionHeaders(" local-token ")).toEqual({
+      Authorization: "Bearer local-token",
+    });
+  });
+
+  test("sends the OpenAI-compatible multipart contract and returns text", async () => {
+    const request = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ text: "transcribed speech" }),
+    });
+    const audio = new File(["audio"], "recording.webm", {
+      type: "audio/webm",
+    });
+
+    await expect(
+      transcribeAudio(
+        audio,
+        {
+          baseUrl: "http://127.0.0.1:10095",
+          model: "FunAudioLLM/Fun-ASR-Nano-2512",
+          apiKey: "local-token",
+        },
+        request,
+      ),
+    ).resolves.toBe("transcribed speech");
+
+    const [endpoint, init] = request.mock.calls[0];
+    expect(endpoint).toBe("http://127.0.0.1:10095/v1/audio/transcriptions");
+    expect(init.headers).toEqual({ Authorization: "Bearer local-token" });
+    expect(init.body.get("model")).toBe("FunAudioLLM/Fun-ASR-Nano-2512");
+    expect(init.body.get("file")).toBeInstanceOf(File);
+  });
+});


### PR DESCRIPTION
## Summary
- add a browser-side multipart transcription client for any OpenAI-compatible `/v1/audio/transcriptions` service
- add persisted Settings fields for a FunASR/SenseVoice-compatible base URL, model, and optional API key
- add a toolbar audio-file action that appends returned text to the current draft without sending it
- document the local-service boundary; NextChat does not bundle a Python runtime or model weights

## Verification
- `corepack yarn test:ci test/stt.test.ts` (3 passed)
- `corepack yarn build` (passed; existing lint plugin warning on `app/constant.ts` remains non-fatal)

Related to #6803. Keep that issue open for maintainer and reporter verification after merge.