### PR TITLE
fix(sync): correct merge direction and remote timestamp in mergeWithUpdate

### DIFF
--- a/app/utils/sync.ts
+++ b/app/utils/sync.ts
@@ -146,20 +146,17 @@ export function mergeAppState(localState: AppState, remoteState: AppState) {
 }
 
 /**
- * Merge state with `lastUpdateTime`, older state will be override
+ * Merge state with `lastUpdateTime`, newer state will override
  */
 export function mergeWithUpdate<T extends { lastUpdateTime?: number }>(
   localState: T,
   remoteState: T,
 ) {
   const localUpdateTime = localState.lastUpdateTime ?? 0;
-  const remoteUpdateTime = localState.lastUpdateTime ?? 1;
+  const remoteUpdateTime = remoteState.lastUpdateTime ?? 0;
 
   if (localUpdateTime < remoteUpdateTime) {
-    merge(remoteState, localState);
-    return { ...remoteState };
-  } else {
     merge(localState, remoteState);
-    return { ...localState };
   }
+  return { ...localState };
 }


### PR DESCRIPTION
`mergeWithUpdate` compared local timestamp against itself and swapped the merge direction, so remote always overwrote local and local edits never reached the cloud.

#### 💻 变更类型 | Change Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] style
- [ ] test
- [ ] docs
- [ ] ci
- [ ] chore
- [ ] build

#### 🔀 变更说明 | Description of Change

修复 `app/utils/sync.ts` 中 `mergeWithUpdate` 的两个复合 bug：

1. `remoteUpdateTime` 误从 `localState.lastUpdateTime` 读取，导致时间戳比较实际是 `local < local`，永远走 else 分支。
2. if/else 两个分支的 `merge()` 调用方向都反了：remote 较新时调用 `merge(remoteState, localState)`（in-place 改 remoteState，而后续上传的是 localState，拿不到远端新值）；local 较新/相等时调用 `merge(localState, remoteState)`（本地新值被远端旧值覆盖）。

合并效果是"remote 永远覆盖 local，然后上传带旧远端值的 localState"。本地编辑的 `customModels`、`modelConfig`、`ttsConfig`、`theme/font`、各 Provider URL/Key 等所有走 `mergeWithUpdate` 合并的字段，每次同步往返都被丢失。

修复：从 `remoteState.lastUpdateTime` 读取 `remoteUpdateTime`；remote 较新时调用 `merge(localState, remoteState)`（in-place 把 remote 合入 local，后续上传 local 时携带远端新值）；local 较新或相等时不合并、保留本地新值。

#### 📝 补充信息 | Additional Information

仅修改 `app/utils/sync.ts` 的 `mergeWithUpdate` 函数（+3/-6 行）。

`mergeWithUpdate` 同时被 `Config` 和 `Access` store 使用，因此影响范围不限于 `customModels`，涵盖所有依赖 `lastUpdateTime` 合并的字段。