### PR TITLE
fix: stop re-applying input template on message retry

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1263,10 +1263,15 @@ function _Chat() {
     deleteMessage(botMessage?.id);
 
     // resend the message
+    // skip template fill because userMessage.content already stores the
+    // template-applied content from the original send; re-applying it would
+    // nest the template on every retry.
     setIsLoading(true);
     const textContent = getMessageTextContent(userMessage);
     const images = getMessageImages(userMessage);
-    chatStore.onUserInput(textContent, images).then(() => setIsLoading(false));
+    chatStore
+      .onUserInput(textContent, images, false, true)
+      .then(() => setIsLoading(false));
     inputRef.current?.focus();
   };
 

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -408,14 +408,18 @@ export const useChatStore = createPersistStore(
         content: string,
         attachImages?: string[],
         isMcpResponse?: boolean,
+        skipTemplateFill?: boolean,
       ) {
         const session = get().currentSession();
         const modelConfig = session.mask.modelConfig;
 
         // MCP Response no need to fill template
-        let mContent: string | MultimodalContent[] = isMcpResponse
-          ? content
-          : fillTemplateWith(content, modelConfig);
+        // Retrying a message also skips the template, since the saved user
+        // message already contains the template-applied content.
+        let mContent: string | MultimodalContent[] =
+          isMcpResponse || skipTemplateFill
+            ? content
+            : fillTemplateWith(content, modelConfig);
 
         if (!isMcpResponse && attachImages && attachImages.length > 0) {
           mContent = [


### PR DESCRIPTION
onResend fetched the already template-filled user message content and passed it back through onUserInput, which called fillTemplateWith again. The existing dedupe (input.startsWith(output)) only catches the first re-send, so subsequent retries nested the template repeatedly.

Add a skipTemplateFill option to onUserInput and pass it from onResend, since the saved user message already stores the template-applied content.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don't modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

- `app/store/chat.ts`: 为 `onUserInput` 新增 `skipTemplateFill` 选项，当其为 true 时跳过 `fillTemplateWith`，直接使用传入的 content。
- `app/components/chat.tsx`: `onResend` 在调用 `onUserInput` 时传入 `skipTemplateFill=true`，因为已保存的用户消息内容已经经过模板填充处理，重复填充会导致嵌套。

#### 📝 补充信息 | Additional Information

- 复现：在设置中配置非默认的输入模板后，点击用户消息或模型回复的重试按钮，原内容会被模板反复嵌套包装，每次重试嵌套一层。
- 根因：`onUserInput` 每次都调用 `fillTemplateWith` 并把填充结果保存进 userMessage；`onResend` 读取已保存内容后再次走 `onUserInput`，于是模板被再次套用。`fillTemplateWith` 内部 `input.startsWith(output)` 的去重仅能挡住第一次，后续重试时 input 已不以原始模板开头（被嵌套结构包裹），去重失效。
- 验证：手动连续多次点击用户消息与模型回复的重试按钮，用户内容保持稳定不再嵌套；首次发送仍正常应用输入模板；MCP 响应路径不受影响（已通过 `isMcpResponse` 跳过模板）。