### PR TITLE
feat: support custom request params (e.g., disable thinking) and enable default parameters (e.g., temperature) by model providers

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -397,3 +397,86 @@ export function getClientApi(provider: ServiceProvider): ClientApi {
       return new ClientApi(ModelProvider.GPT);
   }
 }
+
+// Core fields that must not be overwritten by extraParams
+const PROTECTED_PAYLOAD_KEYS = new Set([
+  "messages",
+  "model",
+  "stream",
+  "temperature",
+  "top_p",
+  "presence_penalty",
+  "frequency_penalty",
+]);
+
+export interface ModelConfigExtras {
+  disableTemperature?: boolean;
+  disableTopP?: boolean;
+  disablePresencePenalty?: boolean;
+  disableFrequencyPenalty?: boolean;
+  extraParams?: string;
+}
+
+/**
+ * Apply model-config extras to a request payload (called after requestPayload
+ * has been constructed in each provider):
+ *   1. Remove parameters flagged as "do not send" so the provider defaults
+ *      are used instead.
+ *   2. Parse modelConfig.extraParams (a JSON string) and merge it into the
+ *      payload.
+ *   3. Protect core fields from being overwritten by extraParams.
+ *
+ * Note: temperature/top_p/presence_penalty/frequency_penalty are in the
+ * protected set because they can be removed by the disable flags above;
+ * adding them back via extraParams would defeat that intent.
+ */
+export function applyModelConfigExtras(
+  modelConfig: ModelConfigExtras,
+  payload: Record<string, any>,
+): Record<string, any> {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+
+  // 1. Remove parameters the user chose not to send
+  if (modelConfig.disableTemperature) {
+    delete payload.temperature;
+  }
+  if (modelConfig.disableTopP) {
+    delete payload.top_p;
+  }
+  if (modelConfig.disablePresencePenalty) {
+    delete payload.presence_penalty;
+  }
+  if (modelConfig.disableFrequencyPenalty) {
+    delete payload.frequency_penalty;
+  }
+
+  // 2. Merge custom request parameters
+  const extraParamsStr = modelConfig.extraParams;
+  if (extraParamsStr && extraParamsStr.trim().length > 0) {
+    try {
+      const extra = JSON.parse(extraParamsStr);
+      if (extra && typeof extra === "object" && !Array.isArray(extra)) {
+        Object.keys(extra).forEach((key) => {
+          if (!PROTECTED_PAYLOAD_KEYS.has(key)) {
+            payload[key] = extra[key];
+          } else {
+            console.warn(
+              `[applyModelConfigExtras] skip protected key "${key}"`,
+            );
+          }
+        });
+      } else {
+        console.warn(
+          "[applyModelConfigExtras] extraParams must be a JSON object, got:",
+          extra,
+        );
+      }
+    } catch (e) {
+      console.warn("[applyModelConfigExtras] invalid extraParams JSON:", e);
+    }
+  }
+
+  return payload;
+}

--- a/app/client/platforms/ai302.ts
+++ b/app/client/platforms/ai302.ts
@@ -20,6 +20,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import {
@@ -116,6 +117,8 @@ export class Ai302Api implements LLMApi {
       // max_tokens: Math.max(modelConfig.max_tokens, 1024),
       // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] openai payload: ", requestPayload);
 

--- a/app/client/platforms/alibaba.ts
+++ b/app/client/platforms/alibaba.ts
@@ -19,6 +19,7 @@ import {
   SpeechOptions,
   MultimodalContent,
   MultimodalContentForAlibaba,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import {
@@ -131,6 +132,18 @@ export class QwenApi implements LLMApi {
         top_p: modelConfig.top_p === 1 ? 0.99 : modelConfig.top_p, // qwen top_p is should be < 1
       },
     };
+
+    // Alibaba nests temperature/top_p inside parameters, so handle the
+    // disable flags specifically for those nested fields
+    if (modelConfig.disableTemperature) {
+      delete (requestPayload.parameters as any).temperature;
+    }
+    if (modelConfig.disableTopP) {
+      delete (requestPayload.parameters as any).top_p;
+    }
+    // Merge custom extraParams at the top level; top-level disable flags
+    // are no-ops here because Alibaba does not use those top-level names
+    applyModelConfigExtras(modelConfig, requestPayload as any);
 
     const controller = new AbortController();
     options.onController?.(controller);

--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -1,5 +1,5 @@
 import { Anthropic, ApiPath } from "@/app/constant";
-import { ChatOptions, getHeaders, LLMApi, SpeechOptions } from "../api";
+import { ChatOptions, getHeaders, LLMApi, SpeechOptions, applyModelConfigExtras } from "../api";
 import {
   useAccessStore,
   useAppConfig,
@@ -190,6 +190,11 @@ export class ClaudeApi implements LLMApi {
       // top_k: modelConfig.top_k,
       top_k: 5,
     };
+
+    // Apply disable flags (temperature/top_p) + merge custom extraParams
+    // presence_penalty / frequency_penalty are not supported by Anthropic,
+    // so those disable flags are effectively no-ops here
+    applyModelConfigExtras(modelConfig, requestBody as any);
 
     const path = this.path(Anthropic.ChatPath);
 

--- a/app/client/platforms/baidu.ts
+++ b/app/client/platforms/baidu.ts
@@ -10,6 +10,7 @@ import {
   LLMModel,
   MultimodalContent,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import Locale from "../../locales";
 import {
@@ -116,6 +117,8 @@ export class ErnieApi implements LLMApi {
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] Baidu payload: ", requestPayload);
 

--- a/app/client/platforms/bytedance.ts
+++ b/app/client/platforms/bytedance.ts
@@ -15,6 +15,7 @@ import {
   LLMModel,
   MultimodalContent,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 
 import { streamWithThink } from "@/app/utils/chat";
@@ -112,6 +113,8 @@ export class DoubaoApi implements LLMApi {
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     const controller = new AbortController();
     options.onController?.(controller);

--- a/app/client/platforms/deepseek.ts
+++ b/app/client/platforms/deepseek.ts
@@ -15,6 +15,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import {
@@ -114,6 +115,8 @@ export class DeepSeekApi implements LLMApi {
       // max_tokens: Math.max(modelConfig.max_tokens, 1024),
       // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] openai payload: ", requestPayload);
 

--- a/app/client/platforms/glm.ts
+++ b/app/client/platforms/glm.ts
@@ -14,6 +14,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import {
@@ -174,6 +175,11 @@ export class ChatGLMApi implements LLMApi {
     const modelType = this.getModelType(modelConfig.model);
     const requestPayload = this.createPayload(messages, modelConfig, options);
     const path = this.path(this.getModelPath(modelType));
+
+    // Apply disable flags + merge custom extraParams (chat only; skip for image/video)
+    if (modelType !== "image" && modelType !== "video") {
+      applyModelConfigExtras(modelConfig, requestPayload as any);
+    }
 
     console.log(`[Request] glm ${modelType} payload: `, requestPayload);
 

--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -6,6 +6,7 @@ import {
   LLMModel,
   LLMUsage,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import {
   useAccessStore,
@@ -180,6 +181,19 @@ export class GeminiProApi implements LLMApi {
         },
       ],
     };
+
+    // Google nests temperature/topP inside generationConfig, so handle the
+    // disable flags specifically for those nested fields
+    if (modelConfig.disableTemperature) {
+      delete (requestPayload.generationConfig as any).temperature;
+    }
+    if (modelConfig.disableTopP) {
+      delete (requestPayload.generationConfig as any).topP;
+    }
+    // Merge custom extraParams at the top level; top-level disable flags
+    // (temperature/top_p/presence_penalty/frequency_penalty) are no-ops here
+    // because Google does not use those top-level field names
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     let shouldStream = !!options.config.stream;
     const controller = new AbortController();

--- a/app/client/platforms/iflytek.ts
+++ b/app/client/platforms/iflytek.ts
@@ -13,6 +13,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import Locale from "../../locales";
 import {
@@ -91,6 +92,8 @@ export class SparkApi implements LLMApi {
       // max_tokens: Math.max(modelConfig.max_tokens, 1024),
       // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] Spark payload: ", requestPayload);
 

--- a/app/client/platforms/moonshot.ts
+++ b/app/client/platforms/moonshot.ts
@@ -20,6 +20,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import { getMessageTextContent } from "@/app/utils";
@@ -91,6 +92,8 @@ export class MoonshotApi implements LLMApi {
       // max_tokens: Math.max(modelConfig.max_tokens, 1024),
       // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] openai payload: ", requestPayload);
 

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -34,6 +34,7 @@ import {
   LLMUsage,
   MultimodalContent,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import Locale from "../../locales";
 import { getClientConfig } from "@/app/config/client";
@@ -263,6 +264,9 @@ export class ChatGPTApi implements LLMApi {
       if (visionModel && !isO1OrO3 && ! isGpt5) {
         requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
       }
+
+      // Apply disable flags + merge custom extraParams (chat only; skip for Dalle3)
+      requestPayload = applyModelConfigExtras(modelConfig, requestPayload as any) as any;
     }
 
     console.log("[Request] openai payload: ", requestPayload);

--- a/app/client/platforms/siliconflow.ts
+++ b/app/client/platforms/siliconflow.ts
@@ -20,6 +20,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import {
@@ -116,6 +117,8 @@ export class SiliconflowApi implements LLMApi {
       // max_tokens: Math.max(modelConfig.max_tokens, 1024),
       // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] openai payload: ", requestPayload);
 

--- a/app/client/platforms/tencent.ts
+++ b/app/client/platforms/tencent.ts
@@ -9,6 +9,7 @@ import {
   LLMModel,
   MultimodalContent,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import Locale from "../../locales";
 import {
@@ -113,13 +114,24 @@ export class HunyuanApi implements LLMApi {
       },
     };
 
-    const requestPayload: RequestPayload = capitalizeKeys({
+    // Tencent payload keys get uppercased by capitalizeKeys, so construct the
+    // raw object conditionally based on disable flags before capitalizing
+    const basePayload: Record<string, any> = {
       model: modelConfig.model,
       messages,
-      temperature: modelConfig.temperature,
-      top_p: modelConfig.top_p,
       stream: options.config.stream,
-    });
+    };
+    if (!modelConfig.disableTemperature) {
+      basePayload.temperature = modelConfig.temperature;
+    }
+    if (!modelConfig.disableTopP) {
+      basePayload.top_p = modelConfig.top_p;
+    }
+    const requestPayload: RequestPayload = capitalizeKeys(basePayload);
+
+    // Merge custom extraParams (top-level). Top-level disable flags are no-ops
+    // here because all keys have been capitalized already
+    applyModelConfigExtras(modelConfig, requestPayload as any);
 
     console.log("[Request] Tencent payload: ", requestPayload);
 

--- a/app/client/platforms/xai.ts
+++ b/app/client/platforms/xai.ts
@@ -15,6 +15,7 @@ import {
   LLMApi,
   LLMModel,
   SpeechOptions,
+  applyModelConfigExtras,
 } from "../api";
 import { getClientConfig } from "@/app/config/client";
 import { getTimeoutMSByModel } from "@/app/utils";
@@ -85,6 +86,8 @@ export class XAIApi implements LLMApi {
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
     };
+
+    applyModelConfigExtras(modelConfig, requestPayload);
 
     console.log("[Request] xai payload: ", requestPayload);
 

--- a/app/components/input-range.tsx
+++ b/app/components/input-range.tsx
@@ -11,6 +11,7 @@ interface InputRangeProps {
   max: string;
   step: string;
   aria: string;
+  disabled?: boolean;
 }
 
 export function InputRange({
@@ -22,6 +23,7 @@ export function InputRange({
   max,
   step,
   aria,
+  disabled,
 }: InputRangeProps) {
   return (
     <div className={clsx(styles["input-range"], className)}>
@@ -35,6 +37,7 @@ export function InputRange({
         max={max}
         step={step}
         onChange={onChange}
+        disabled={disabled}
       ></input>
     </div>
   );

--- a/app/components/model-config.module.scss
+++ b/app/components/model-config.module.scss
@@ -5,3 +5,96 @@
     white-space: normal;
   }
 }
+
+// Container for a numeric param slider + "do not send" checkbox.
+// Slider fills the right-side cell at the same width as other <input>
+// controls (max-width: 50% matches globals.scss).
+// Checkbox sits below the slider, right-aligned to match the slider's
+// right edge so it visually attaches to the same control block.
+.param-with-toggle {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  width: 100%;
+}
+
+.param-disable-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--black);
+  opacity: 0.7;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+
+  input[type="checkbox"] {
+    cursor: pointer;
+  }
+}
+
+// JSON editor block — same rounded-border, padding, and width as other
+// <input type="text"> controls, but with configurable height.
+.extra-params-input {
+  width: 100%;
+  max-width: 50%;
+  min-height: 80px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: var(--border-in-light);
+  background: var(--white);
+  color: var(--black);
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--gray);
+  }
+}
+
+// Validation + save row under the JSON textarea.
+.extra-params-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  max-width: 50%;
+  margin-top: 4px;
+
+  .extra-params-status {
+    font-size: 12px;
+    font-family: inherit;
+
+    &.valid {
+      color: #2e7d32;
+    }
+    &.invalid {
+      color: #c62828;
+    }
+    &.empty {
+      color: var(--gray);
+    }
+  }
+
+  .extra-params-save {
+    appearance: none;
+    border: var(--border-in-light);
+    border-radius: 8px;
+    min-height: 28px;
+    padding: 0 14px;
+    font-size: 12px;
+    cursor: pointer;
+    background: var(--white);
+    color: var(--black);
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+}

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+import { useState, useMemo, useEffect } from "react";
 import { ServiceProvider } from "@/app/constant";
 import { ModalConfigValidator, ModelConfig } from "../store";
 
@@ -53,41 +55,72 @@ export function ModelConfigList(props: {
         title={Locale.Settings.Temperature.Title}
         subTitle={Locale.Settings.Temperature.SubTitle}
       >
-        <InputRange
-          aria={Locale.Settings.Temperature.Title}
-          value={props.modelConfig.temperature?.toFixed(1)}
-          min="0"
-          max="1" // lets limit it to 0-1
-          step="0.1"
-          onChange={(e) => {
-            props.updateConfig(
-              (config) =>
-                (config.temperature = ModalConfigValidator.temperature(
-                  e.currentTarget.valueAsNumber,
-                )),
-            );
-          }}
-        ></InputRange>
+        <div className={styles["param-with-toggle"]}>
+          <InputRange
+            aria={Locale.Settings.Temperature.Title}
+            value={props.modelConfig.temperature?.toFixed(1)}
+            min="0"
+            max="1" // lets limit it to 0-1
+            step="0.1"
+            disabled={props.modelConfig.disableTemperature}
+            onChange={(e) => {
+              props.updateConfig(
+                (config) =>
+                  (config.temperature = ModalConfigValidator.temperature(
+                    e.currentTarget.valueAsNumber,
+                  )),
+              );
+            }}
+          ></InputRange>
+          <label className={styles["param-disable-label"]}>
+            <input
+              type="checkbox"
+              checked={props.modelConfig.disableTemperature}
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) =>
+                    (config.disableTemperature = e.currentTarget.checked),
+                )
+              }
+            />
+            <span>{Locale.Settings.DisableParam}</span>
+          </label>
+        </div>
       </ListItem>
       <ListItem
         title={Locale.Settings.TopP.Title}
         subTitle={Locale.Settings.TopP.SubTitle}
       >
-        <InputRange
-          aria={Locale.Settings.TopP.Title}
-          value={(props.modelConfig.top_p ?? 1).toFixed(1)}
-          min="0"
-          max="1"
-          step="0.1"
-          onChange={(e) => {
-            props.updateConfig(
-              (config) =>
-                (config.top_p = ModalConfigValidator.top_p(
-                  e.currentTarget.valueAsNumber,
-                )),
-            );
-          }}
-        ></InputRange>
+        <div className={styles["param-with-toggle"]}>
+          <InputRange
+            aria={Locale.Settings.TopP.Title}
+            value={(props.modelConfig.top_p ?? 1).toFixed(1)}
+            min="0"
+            max="1"
+            step="0.1"
+            disabled={props.modelConfig.disableTopP}
+            onChange={(e) => {
+              props.updateConfig(
+                (config) =>
+                  (config.top_p = ModalConfigValidator.top_p(
+                    e.currentTarget.valueAsNumber,
+                  )),
+              );
+            }}
+          ></InputRange>
+          <label className={styles["param-disable-label"]}>
+            <input
+              type="checkbox"
+              checked={props.modelConfig.disableTopP}
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) => (config.disableTopP = e.currentTarget.checked),
+                )
+              }
+            />
+            <span>{Locale.Settings.DisableParam}</span>
+          </label>
+        </div>
       </ListItem>
       <ListItem
         title={Locale.Settings.MaxTokens.Title}
@@ -116,81 +149,91 @@ export function ModelConfigList(props: {
             title={Locale.Settings.PresencePenalty.Title}
             subTitle={Locale.Settings.PresencePenalty.SubTitle}
           >
-            <InputRange
-              aria={Locale.Settings.PresencePenalty.Title}
-              value={props.modelConfig.presence_penalty?.toFixed(1)}
-              min="-2"
-              max="2"
-              step="0.1"
-              onChange={(e) => {
-                props.updateConfig(
-                  (config) =>
-                    (config.presence_penalty =
-                      ModalConfigValidator.presence_penalty(
-                        e.currentTarget.valueAsNumber,
-                      )),
-                );
-              }}
-            ></InputRange>
+            <div className={styles["param-with-toggle"]}>
+              <InputRange
+                aria={Locale.Settings.PresencePenalty.Title}
+                value={props.modelConfig.presence_penalty?.toFixed(1)}
+                min="-2"
+                max="2"
+                step="0.1"
+                disabled={props.modelConfig.disablePresencePenalty}
+                onChange={(e) => {
+                  props.updateConfig(
+                    (config) =>
+                      (config.presence_penalty =
+                        ModalConfigValidator.presence_penalty(
+                          e.currentTarget.valueAsNumber,
+                        )),
+                  );
+                }}
+              ></InputRange>
+              <label className={styles["param-disable-label"]}>
+                <input
+                  type="checkbox"
+                  checked={props.modelConfig.disablePresencePenalty}
+                  onChange={(e) =>
+                    props.updateConfig(
+                      (config) =>
+                        (config.disablePresencePenalty =
+                          e.currentTarget.checked),
+                    )
+                  }
+                />
+                <span>{Locale.Settings.DisableParam}</span>
+              </label>
+            </div>
           </ListItem>
 
           <ListItem
             title={Locale.Settings.FrequencyPenalty.Title}
             subTitle={Locale.Settings.FrequencyPenalty.SubTitle}
           >
-            <InputRange
-              aria={Locale.Settings.FrequencyPenalty.Title}
-              value={props.modelConfig.frequency_penalty?.toFixed(1)}
-              min="-2"
-              max="2"
-              step="0.1"
-              onChange={(e) => {
-                props.updateConfig(
-                  (config) =>
-                    (config.frequency_penalty =
-                      ModalConfigValidator.frequency_penalty(
-                        e.currentTarget.valueAsNumber,
-                      )),
-                );
-              }}
-            ></InputRange>
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.InjectSystemPrompts.Title}
-            subTitle={Locale.Settings.InjectSystemPrompts.SubTitle}
-          >
-            <input
-              aria-label={Locale.Settings.InjectSystemPrompts.Title}
-              type="checkbox"
-              checked={props.modelConfig.enableInjectSystemPrompts}
-              onChange={(e) =>
-                props.updateConfig(
-                  (config) =>
-                    (config.enableInjectSystemPrompts =
-                      e.currentTarget.checked),
-                )
-              }
-            ></input>
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.InputTemplate.Title}
-            subTitle={Locale.Settings.InputTemplate.SubTitle}
-          >
-            <input
-              aria-label={Locale.Settings.InputTemplate.Title}
-              type="text"
-              value={props.modelConfig.template}
-              onChange={(e) =>
-                props.updateConfig(
-                  (config) => (config.template = e.currentTarget.value),
-                )
-              }
-            ></input>
+            <div className={styles["param-with-toggle"]}>
+              <InputRange
+                aria={Locale.Settings.FrequencyPenalty.Title}
+                value={props.modelConfig.frequency_penalty?.toFixed(1)}
+                min="-2"
+                max="2"
+                step="0.1"
+                disabled={props.modelConfig.disableFrequencyPenalty}
+                onChange={(e) => {
+                  props.updateConfig(
+                    (config) =>
+                      (config.frequency_penalty =
+                        ModalConfigValidator.frequency_penalty(
+                          e.currentTarget.valueAsNumber,
+                        )),
+                  );
+                }}
+              ></InputRange>
+              <label className={styles["param-disable-label"]}>
+                <input
+                  type="checkbox"
+                  checked={props.modelConfig.disableFrequencyPenalty}
+                  onChange={(e) =>
+                    props.updateConfig(
+                      (config) =>
+                        (config.disableFrequencyPenalty =
+                          e.currentTarget.checked),
+                    )
+                  }
+                />
+                <span>{Locale.Settings.DisableParam}</span>
+              </label>
+            </div>
           </ListItem>
         </>
       )}
+
+      {/* Custom request params — sits with the other send-parameter items.
+          Rendered outside the Google-only block so all providers see it. */}
+      <ExtraParamsEditor
+        value={props.modelConfig.extraParams}
+        onChange={(val) =>
+          props.updateConfig((config) => (config.extraParams = val))
+        }
+      />
+
       <ListItem
         title={Locale.Settings.HistoryCount.Title}
         subTitle={Locale.Settings.HistoryCount.SubTitle}
@@ -269,5 +312,109 @@ export function ModelConfigList(props: {
         </Select>
       </ListItem>
     </>
+  );
+}
+
+/**
+ * Controlled JSON textarea + validator + Save button.
+ *
+ * Renders inside a ListItem body that sits to the right of the
+ * title/sub-title (same horizontal two-column layout as every
+ * other setting).
+ *
+ * The editor uses internal draft state so the underlying modelConfig
+ * is only updated when the user clicks Save (and the JSON parses
+ * cleanly). This avoids half-edited invalid JSON leaking into
+ * applyModelConfigExtras on every keystroke.
+ */
+function ExtraParamsEditor(props: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [draft, setDraft] = useState(props.value);
+
+  // Keep draft in sync if config changes elsewhere (e.g. reset).
+  useEffect(() => {
+    setDraft(props.value);
+  }, [props.value]);
+
+  const trimmed = draft.trim();
+  const status = useMemo(() => {
+    if (!trimmed) return { kind: "empty" as const, text: "" };
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {
+          kind: "invalid" as const,
+          text: Locale.Settings.ExtraParams.StatusObject,
+        };
+      }
+      return { kind: "valid" as const, text: Locale.Settings.ExtraParams.StatusValid };
+    } catch (e: any) {
+      return {
+        kind: "invalid" as const,
+        text: Locale.Settings.ExtraParams.StatusInvalid + ": " + (e?.message ?? String(e)),
+      };
+    }
+  }, [trimmed]);
+
+  const isDirty = draft !== props.value;
+  const canSave = trimmed.length === 0 || status.kind === "valid";
+
+  function handleSave() {
+    if (!canSave) return;
+    props.onChange(trimmed);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    // Ctrl/Cmd + Enter to save
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
+
+  return (
+    <ListItem
+      title={Locale.Settings.ExtraParams.Title}
+      subTitle={Locale.Settings.ExtraParams.SubTitle}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          width: "100%",
+        }}
+      >
+        <textarea
+          className={styles["extra-params-input"]}
+          aria-label={Locale.Settings.ExtraParams.Title}
+          value={draft}
+          placeholder={Locale.Settings.ExtraParams.Placeholder}
+          spellCheck={false}
+          rows={4}
+          onChange={(e) => setDraft(e.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <div className={styles["extra-params-row"]}>
+          <span className={`${styles["extra-params-status"]} ${styles[status.kind]}`}>
+            {trimmed.length === 0
+              ? Locale.Settings.ExtraParams.StatusEmpty
+              : status.text}
+          </span>
+          <button
+            className={styles["extra-params-save"]}
+            onClick={handleSave}
+            disabled={!canSave}
+            title={canSave ? "" : Locale.Settings.ExtraParams.SaveDisabledHint}
+          >
+            {isDirty
+              ? Locale.Settings.ExtraParams.SaveButton
+              : Locale.Settings.ExtraParams.SavedButton}
+          </button>
+        </div>
+      </div>
+    </ListItem>
   );
 }

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -576,6 +576,21 @@ const cn = {
       Title: "频率惩罚度 (frequency_penalty)",
       SubTitle: "值越大，越有可能降低重复字词",
     },
+    DisableParam: "不提供（采用模型提供商默认）",
+    ExtraParams: {
+      Title: "自定义请求参数",
+      SubTitle:
+        "以 JSON 格式追加自定义请求参数（如 thinking）。messages/model/stream 等核心字段会被保护，不会被覆盖",
+      Placeholder:
+        '例如：\n{"thinking":{"type":"disabled"}}\n注意：仅会合并到顶层请求体，不会覆盖受保护字段',
+      StatusEmpty: "未填写 — 不附加额外参数",
+      StatusValid: "JSON 合法",
+      StatusObject: "顶层值必须是 JSON 对象，不能是数组或原始类型",
+      StatusInvalid: "JSON 格式错误",
+      SaveButton: "保存",
+      SavedButton: "已保存",
+      SaveDisabledHint: "修复 JSON 语法后才能保存",
+    },
     TTS: {
       Enable: {
         Title: "启用文本转语音",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -583,6 +583,21 @@ const en: LocaleType = {
       SubTitle:
         "A larger value decreasing the likelihood to repeat the same line",
     },
+    DisableParam: "Do not send (use provider default)",
+    ExtraParams: {
+      Title: "Custom Request Parameters",
+      SubTitle:
+        "Append custom request parameters as JSON (e.g. thinking). Core fields like messages/model/stream are protected and will not be overwritten",
+      Placeholder:
+        'e.g.\n{"thinking":{"type":"disabled"}}\nNote: merged into the top-level request body only; protected fields are skipped',
+      StatusEmpty: "Empty — no extra params",
+      StatusValid: "Valid JSON object",
+      StatusObject: "Top-level value must be a JSON object, not array or primitive",
+      StatusInvalid: "Invalid JSON",
+      SaveButton: "Save",
+      SavedButton: "Saved",
+      SaveDisabledHint: "Fix the JSON syntax before saving",
+    },
     TTS: {
       Enable: {
         Title: "Enable TTS",

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -78,6 +78,13 @@ export const DEFAULT_CONFIG = {
     compressProviderName: "",
     enableInjectSystemPrompts: true,
     template: config?.template ?? DEFAULT_INPUT_TEMPLATE,
+    // Omit these parameters (use provider defaults instead)
+    disableTemperature: false,
+    disableTopP: false,
+    disablePresencePenalty: false,
+    disableFrequencyPenalty: false,
+    // Custom request parameters (JSON string, merged into the request payload)
+    extraParams: "",
     size: "1024x1024" as ModelSize,
     quality: "standard" as DalleQuality,
     style: "vivid" as DalleStyle,
@@ -195,7 +202,7 @@ export const useAppConfig = createPersistStore(
   }),
   {
     name: StoreKey.Config,
-    version: 4.1,
+    version: 4.3,
 
     merge(persistedState, currentState) {
       const state = persistedState as ChatConfig | undefined;
@@ -255,6 +262,17 @@ export const useAppConfig = createPersistStore(
           DEFAULT_CONFIG.modelConfig.compressProviderName;
       }
 
+      if (version < 4.2) {
+        state.enableMcp = DEFAULT_CONFIG.enableMcp;
+      }
+
+      if (version < 4.3) {
+        state.modelConfig.disableTemperature = false;
+        state.modelConfig.disableTopP = false;
+        state.modelConfig.disablePresencePenalty = false;
+        state.modelConfig.disableFrequencyPenalty = false;
+        state.modelConfig.extraParams = "";
+      }
       return state as any;
     },
   },


### PR DESCRIPTION
<img width="1160" height="992" alt="screen_shot" src="https://github.com/user-attachments/assets/7faa8983-e0fc-4ffd-8854-c50f2e55dbcf" />

- Add `extraParams` (JSON string) to modelConfig for injecting custom request body fields — e.g. `{"thinking":{"type":"disabled"}}` to turn off DeepSeek's thinking mode, or `{"thinking":{"type":"enabled","budget_tokens":2000}}` to control it. Merged into payload with core fields (`messages`/`model`/`stream`) protected from being overwritten.
- Add 4 disable flags (`disableTemperature`/`disableTopP`/`disablePresencePenalty`/`disableFrequencyPenalty`); when checked the corresponding param is omitted from the request so the provider's default value is used (useful for providers like DeepSeek whose thinking models have their own optimal sampling defaults).
- Introduce `applyModelConfigExtras` helper and apply it across all providers after requestPayload construction.
- Bump config version to 4.3 with migration for the new fields.
- Add UI checkboxes per sampling param + JSON editor block, plus i18n (cn/en); other locales fall back to en.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don't modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

Two tightly related capabilities for finer-grained control over LLM requests:

**1. Omit default sampling params (use provider defaults)**

Today NextChat always sends `temperature`, `top_p`, `presence_penalty`, `frequency_penalty` with fixed defaults. Some providers (e.g. DeepSeek V3/R1, newer reasoning models) have their own sensible defaults — or even disallow certain params — and forcing ours can degrade output. Each param now has a "Do not send (use provider default)" checkbox; checked → the key is simply deleted from the request payload before it goes out.

**2. Inject arbitrary custom params**

Provider APIs keep evolving. Recent examples: DeepSeek's `thinking` block, Anthropic's `reasoning`, Alibaba's `enable_search`. Rather than adding one UI toggle per new param, a single JSON textarea accepts any key/value and merges it into the request body. Core fields (`messages`, `model`, `stream`) and the 4 sampling params above are protected so users can't accidentally break the request.

Both are handled by one helper, `applyModelConfigExtras`, called after every provider finishes building its requestPayload — no provider needs to know about the other's disable logic.

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->

- 21 files changed, 382 insertions(+), 68 deletions(-)
- Tested on providers with nested param structures (Google → `generationConfig`, Alibaba → `parameters`, Tencent → `capitalizeKeys`, Anthropic → no presence_penalty/frequency_penalty). Each has a short inline comment noting how disable flags interact with that provider's payload shape.
- Config version bump 4.2 → 4.3 with migration block initialising all 5 new fields for existing users.
- Chinese/English locale strings added; other languages automatically fall back to English.

