### PR TITLE
feat: make input template a multiline textarea with auto-grow

### DIFF
--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -3,11 +3,13 @@ import { ModalConfigValidator, ModelConfig } from "../store";
 
 import Locale from "../locales";
 import { InputRange } from "./input-range";
-import { ListItem, Select } from "./ui-lib";
+import { Input, ListItem, Select } from "./ui-lib";
 import { useAllModels } from "../utils/hooks";
 import { groupBy } from "lodash-es";
 import styles from "./model-config.module.scss";
 import { getModelProvider } from "../utils/model";
+import { useEffect, useRef, useState } from "react";
+import { autoGrowTextArea } from "../utils";
 
 export function ModelConfigList(props: {
   modelConfig: ModelConfig;
@@ -20,6 +22,16 @@ export function ModelConfigList(props: {
   );
   const value = `${props.modelConfig.model}@${props.modelConfig?.providerName}`;
   const compressModelValue = `${props.modelConfig.compressModel}@${props.modelConfig?.compressProviderName}`;
+
+  // auto-grow input template textarea: small at rest, expands when focused
+  const templateRef = useRef<HTMLTextAreaElement>(null);
+  const [templateFocused, setTemplateFocused] = useState(false);
+  const [templateRows, setTemplateRows] = useState(2);
+  useEffect(() => {
+    if (!templateRef.current) return;
+    const rows = autoGrowTextArea(templateRef.current);
+    setTemplateRows(templateFocused ? Math.min(20, Math.max(4, rows)) : 2);
+  }, [props.modelConfig.template, templateFocused]);
 
   return (
     <>
@@ -178,16 +190,19 @@ export function ModelConfigList(props: {
             title={Locale.Settings.InputTemplate.Title}
             subTitle={Locale.Settings.InputTemplate.SubTitle}
           >
-            <input
+            <Input
               aria-label={Locale.Settings.InputTemplate.Title}
-              type="text"
+              ref={templateRef}
+              rows={templateRows}
               value={props.modelConfig.template}
+              onFocus={() => setTemplateFocused(true)}
+              onBlur={() => setTemplateFocused(false)}
               onChange={(e) =>
                 props.updateConfig(
                   (config) => (config.template = e.currentTarget.value),
                 )
               }
-            ></input>
+            />
           </ListItem>
         </>
       )}

--- a/app/components/ui-lib.tsx
+++ b/app/components/ui-lib.tsx
@@ -21,6 +21,7 @@ import React, {
   useState,
   useCallback,
   useRef,
+  forwardRef,
 } from "react";
 import { IconButton } from "./button";
 import { Avatar } from "./emoji";
@@ -260,14 +261,17 @@ export type InputProps = React.HTMLProps<HTMLTextAreaElement> & {
   rows?: number;
 };
 
-export function Input(props: InputProps) {
-  return (
-    <textarea
-      {...props}
-      className={clsx(styles["input"], props.className)}
-    ></textarea>
-  );
-}
+export const Input = forwardRef<HTMLTextAreaElement, InputProps>(
+  function Input(props, ref) {
+    return (
+      <textarea
+        ref={ref}
+        {...props}
+        className={clsx(styles["input"], props.className)}
+      ></textarea>
+    );
+  },
+);
 
 export function PasswordInput(
   props: HTMLProps<HTMLInputElement> & { aria?: string },


### PR DESCRIPTION
<img width="1140" height="447" alt="fe21d41e-4441-46d5-9458-d5d41162a0d8" src="https://github.com/user-attachments/assets/d303a809-f0c3-4f53-96da-d5280b096a59" />

The Input Template field in model config was a single-line <input>, so newlines could not be entered and long templates were hard to view.

Switch it to the shared ui-lib Input (textarea) and add auto-grow: the field stays compact (2 rows) at rest and expands to fit the content (4-20 rows) when focused, mirroring the chat input box behavior. Also wrap the ui-lib Input with forwardRef so callers can access the DOM node for measurement; this is backward compatible.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->
